### PR TITLE
Revise lazy access names & kinks

### DIFF
--- a/code/_global_vars/lists/flavor.dm
+++ b/code/_global_vars/lists/flavor.dm
@@ -100,7 +100,7 @@ GLOBAL_LIST_INIT(music_tracks, list(
 
 /proc/setup_music_tracks(var/list/tracks)
 	. = list()
-	var/track_list = LAZYLEN(tracks) ? tracks : GLOB.music_tracks
+	var/track_list = LAZY_LENGTH(tracks) ? tracks : GLOB.music_tracks
 	for(var/track_name in track_list)
 		var/track_path = track_list[track_name]
 		. += new/datum/track(track_name, track_path)

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -18,7 +18,7 @@
 	return max_z
 
 /proc/living_observers_present(var/list/zlevels)
-	if(LAZYLEN(zlevels))
+	if(LAZY_LENGTH(zlevels))
 		for(var/A in GLOB.player_list) //if a tree ticks on the empty zlevel does it really tick
 			var/mob/M = A
 			if(M.stat != DEAD) //(no it doesn't)

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -129,29 +129,31 @@
 // All of these are null-safe, you can use them without knowing if the list var is initialized yet
 
 //Picks from the list, with some safeties, and returns the "default" arg if it fails
-#define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
+#define DEFAULT_PICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
 // Ensures L is initailized after this point
-#define LAZYINITLIST(L) if (!L) L = list()
+#define LAZY_INIT(L) if (!L) L = list()
 // Sets a L back to null iff it is empty
-#define UNSETEMPTY(L) if (L && !L.len) L = null
-// Removes I from list L, and sets I to null if it is now empty
-#define LAZYREMOVE(L, I) if(L) { L -= I; if(!L.len) { L = null; } }
-// Adds I to L, initalizing L if necessary
-#define LAZYADD(L, I) if(!L) { L = list(); } L += I;
-// Insert I into L at position X, initalizing L if necessary
-#define LAZYINSERT(L, I, X) if(!L) { L = list(); } L.Insert(X, I);
-// Adds I to L, initalizing L if necessary, if I is not already in L
-#define LAZYDISTINCTADD(L, I) if(!L) { L = list(); } L |= I;
-// Sets L[A] to I, initalizing L if necessary
-#define LAZYSET(L, A, I) if(!L) { L = list(); } L[A] = I;
-// Reads I from L safely - Works with both associative and traditional lists.
-#define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= L.len ? L[I] : null) : L[I]) : null)
+#define UNSET_EMPTY(L) if (L && !L.len) L = null
 // Reads the length of L, returning 0 if null
-#define LAZYLEN(L) length(L)
+#define LAZY_LENGTH(L) (length(L))
 // Safely checks if I is in L
-#define LAZYISIN(L, I) (L ? (I in L) : FALSE)
+#define LAZY_IS_IN(L, I) (L && (I in L))
 // Null-safe L.Cut()
-#define LAZYCLEARLIST(L) if(L) L.Cut()
+#define LAZY_CLEAR(L) if(L) L.Cut()
+// Removes I from list L, and sets I to null if it is now empty
+#define LAZY_REMOVE(L, I) if(L) { L -= I; if(!L.len) { L = null; } }
+// Adds I to L, initalizing L if necessary
+#define LAZY_ADD(L, I) if(!L) { L = list(); } L += I;
+// Insert I into L at position X, initalizing L if necessary
+#define LAZY_INSERT(L, I, X) if(!L) { L = list(); } L.Insert(X, I);
+// Adds I to L, initalizing L if necessary, if I is not already in L
+#define LAZY_ADD_UNIQUE(L, I) if(!L) { L = list(); } L |= I;
+// Sets L[A] to I, initalizing L if necessary
+#define LAZY_SET(L, A, I) if(!L) { L = list(); } L[A] = I;
+// Reads I from L safely - numerical lists only.
+#define LAZY_ACCESS(L, I) (!!L && ((I > 0 && I <= L.len) && L[I]) || null)
+// Reads K from L safely - associative lists only.
+#define LAZY_ACCESS_ASSOC(L, K) ((!!LAZY_IS_IN(L, K) && L[K]) || null)
 // Reads L or an empty list if L is not a list.  Note: Does NOT assign, L may be an expression.
 #define SANITIZE_LIST(L) ( islist(L) ? L : list() )
 

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -131,7 +131,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	var/FireHim = FALSE
 	if(istype(BadBoy))
 		msg = null
-		LAZYINITLIST(BadBoy.failure_strikes)
+		LAZY_INIT(BadBoy.failure_strikes)
 		switch(++BadBoy.failure_strikes[BadBoy.type])
 			if(2)
 				msg = "The [BadBoy.name] subsystem was the last to fire for 2 controller restarts. It will be recovered now and disabled if it happens again."

--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -26,7 +26,7 @@ SUBSYSTEM_DEF(atoms)
 
 	initialized = INITIALIZATION_INNEW_MAPLOAD
 
-	LAZYINITLIST(late_loaders)
+	LAZY_INIT(late_loaders)
 
 	var/count
 	var/list/mapload_arg = list(TRUE)

--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -15,7 +15,7 @@ SUBSYSTEM_DEF(materials)
 
 /datum/controller/subsystem/materials/proc/build_material_lists()
 
-	if(LAZYLEN(materials))
+	if(LAZY_LENGTH(materials))
 		return
 
 	materials =         list()
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(materials)
 			materials_by_name[lowertext(new_mineral.name)] = new_mineral
 			if(new_mineral.ore_smelts_to || new_mineral.ore_compresses_to)
 				processable_ores[new_mineral.name] = TRUE
-			if(new_mineral.alloy_product && LAZYLEN(new_mineral.alloy_materials))
+			if(new_mineral.alloy_product && LAZY_LENGTH(new_mineral.alloy_materials))
 				alloy_products[new_mineral] = TRUE
 				for(var/component in new_mineral.alloy_materials)
 					processable_ores[component] = TRUE

--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -59,7 +59,7 @@ SUBSYSTEM_DEF(shuttle)
 	for(var/landmark_tag in given_sector.initial_generic_waypoints)
 		if(!try_add_landmark_tag(landmark_tag, given_sector))
 			landmarks_still_needed[landmark_tag] = given_sector
-	
+
 	for(var/shuttle_name in given_sector.initial_restricted_waypoints)
 		for(var/landmark_tag in given_sector.initial_restricted_waypoints[shuttle_name])
 			if(!try_add_landmark_tag(landmark_tag, given_sector))
@@ -95,7 +95,7 @@ SUBSYSTEM_DEF(shuttle)
 
 /datum/controller/subsystem/shuttle/proc/initialise_shuttle(var/shuttle_type, during_init = FALSE)
 	if(!initialized && !during_init)
-		LAZYADD(shuttles_to_initialize, shuttle_type)
+		LAZY_ADD(shuttles_to_initialize, shuttle_type)
 		return //We'll get back to it during init.
 	var/datum/shuttle/shuttle = shuttle_type
 	if(initial(shuttle.category) != shuttle_type)

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -250,7 +250,7 @@ SUBSYSTEM_DEF(timer)
 	name = "Timer: " + num2text(id, 8) + ", TTR: [timeToRun], Flags: [jointext(bitfield2list(flags, list("TIMER_UNIQUE", "TIMER_OVERRIDE", "TIMER_CLIENT_TIME", "TIMER_STOPPABLE", "TIMER_NO_HASH_WAIT")), ", ")], callBack: [REF(callBack)], callBack.object: [callBack.object]\ref[callBack.object]([getcallingtype()]), callBack.delegate:[callBack.delegate]([callBack.arguments ? callBack.arguments.Join(", ") : ""])"
 
 	if (callBack.object != GLOBAL_PROC)
-		LAZYADD(callBack.object.active_timers, src)
+		LAZY_ADD(callBack.object.active_timers, src)
 
 	if (flags & TIMER_CLIENT_TIME)
 		//sorted insert
@@ -303,7 +303,7 @@ SUBSYSTEM_DEF(timer)
 
 	if (callBack && callBack.object && callBack.object != GLOBAL_PROC && callBack.object.active_timers)
 		callBack.object.active_timers -= src
-		UNSETEMPTY(callBack.object.active_timers)
+		UNSET_EMPTY(callBack.object.active_timers)
 
 	callBack = null
 

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(vote)
 		if(VOTE_PROCESS_COMPLETE)
 			active_vote.tally_result()      // Does math to figure out who won. Data is stored on the vote datum.
 			active_vote.report_result()     // Announces the result; possibly alerts other entities of the result.
-			LAZYADD(old_votes, active_vote) // Store the datum for future reference.
+			LAZY_ADD(old_votes, active_vote) // Store the datum for future reference.
 			reset()
 			return
 		if(VOTE_PROCESS_ONGOING)

--- a/code/datums/extensions/label.dm
+++ b/code/datums/extensions/label.dm
@@ -15,9 +15,9 @@
 	if(!CanAttachLabel(user, label))
 		return
 
-	if(!LAZYLEN(labels))
+	if(!LAZY_LENGTH(labels))
 		atom_holder.verbs += /atom/proc/RemoveLabel
-	LAZYADD(labels, label)
+	LAZY_ADD(labels, label)
 
 	user.visible_message("<span class='notice'>\The [user] attaches a label to \the [atom_holder].</span>", \
 						 "<span class='notice'>You attach a label, '[label]', to \the [atom_holder].</span>")
@@ -30,8 +30,8 @@
 	if(!(label in labels))
 		return
 
-	LAZYREMOVE(labels, label)
-	if(!LAZYLEN(labels))
+	LAZY_REMOVE(labels, label)
+	if(!LAZY_LENGTH(labels))
 		atom_holder.verbs -= /atom/proc/RemoveLabel
 
 	var/full_label = " ([label])"
@@ -51,7 +51,7 @@
 // in case something appends strings to something that's labelled rather than replace the name outright
 // Non-printable characters should be of help if this comes up
 /datum/extension/labels/proc/AppendLabelsToName(var/name)
-	if(!LAZYLEN(labels))
+	if(!LAZY_LENGTH(labels))
 		return name
 	. = list(name)
 	for(var/entry in labels)
@@ -67,7 +67,7 @@
 
 /datum/extension/labels/proc/ExcessLabelLength(var/label, var/user)
 	. = length(label) + 3 // Each label also adds a space and two brackets when applied to a name
-	if(LAZYLEN(labels))
+	if(LAZY_LENGTH(labels))
 		for(var/entry in labels)
 			. += length(entry) + 3
 	. = . > 64 ? TRUE : FALSE
@@ -77,7 +77,7 @@
 /proc/get_attached_labels(var/atom/source)
 	if(has_extension(source, /datum/extension/labels))
 		var/datum/extension/labels/L = get_extension(source, /datum/extension/labels)
-		if(LAZYLEN(L.labels))
+		if(LAZY_LENGTH(L.labels))
 			return L.labels.Copy()
 		return list()
 

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -6,18 +6,18 @@
 /datum/movement_handler/mob/relayed_movement/MayMove(var/mob/mover, var/is_external)
 	if(is_external)
 		return MOVEMENT_PROCEED
-	if(mover == mob && !(prevent_host_move && LAZYLEN(allowed_movers) && !LAZYISIN(allowed_movers, mover)))
+	if(mover == mob && !(prevent_host_move && LAZY_LENGTH(allowed_movers) && !LAZY_IS_IN(allowed_movers, mover)))
 		return MOVEMENT_PROCEED
-	if(LAZYISIN(allowed_movers, mover))
+	if(LAZY_IS_IN(allowed_movers, mover))
 		return MOVEMENT_PROCEED
 
 	return MOVEMENT_STOP
 
 /datum/movement_handler/mob/relayed_movement/proc/AddAllowedMover(var/mover)
-	LAZYDISTINCTADD(allowed_movers, mover)
+	LAZY_ADD_UNIQUE(allowed_movers, mover)
 
 /datum/movement_handler/mob/relayed_movement/proc/RemoveAllowedMover(var/mover)
-	LAZYREMOVE(allowed_movers, mover)
+	LAZY_REMOVE(allowed_movers, mover)
 
 // Admin object possession
 /datum/movement_handler/mob/admin_possess/DoMove(var/direction)
@@ -187,7 +187,7 @@
 			to_chat(mob, "<span class='notice'>You're buckled to \the [mob.buckled]!</span>")
 		return MOVEMENT_STOP
 
-	if(LAZYLEN(mob.pinned))
+	if(LAZY_LENGTH(mob.pinned))
 		if(mover == mob)
 			to_chat(mob, "<span class='notice'>You're pinned down by \a [mob.pinned[1]]!</span>")
 		return MOVEMENT_STOP
@@ -256,7 +256,7 @@
 	. = 0
 	// TODO: Look into making grabs use movement events instead, this is a mess.
 	var/list/L = mob.ret_grab()
-	if(LAZYLEN(L))
+	if(LAZY_LENGTH(L))
 		var/turf/T = get_step(mob,reverse_direction(direction))
 		L -= mob
 		for(var/mob/M in L)

--- a/code/datums/movement/movement.dm
+++ b/code/datums/movement/movement.dm
@@ -5,7 +5,7 @@ var/const/MOVEMENT_PROCEED = 0x0004
 var/const/MOVEMENT_STOP    = 0x0008
 
 #define INIT_MOVEMENT_HANDLERS \
-if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
+if(LAZY_LENGTH(movement_handlers) && ispath(movement_handlers[1])) { \
 	var/new_handlers = list(); \
 	for(var/path in movement_handlers){ \
 		var/arguments = movement_handlers[path];   \
@@ -15,14 +15,14 @@ if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
 	movement_handlers= new_handlers; \
 }
 
-#define REMOVE_AND_QDEL(X) LAZYREMOVE(movement_handlers, X); qdel(X);
+#define REMOVE_AND_QDEL(X) LAZY_REMOVE(movement_handlers, X); qdel(X);
 
 /atom/movable
 	var/list/movement_handlers
 
 // We don't want to check for subtypes, hence why we don't call is_path_in_list(), etc.
 /atom/movable/proc/HasMovementHandler(var/handler_path)
-	if(!LAZYLEN(movement_handlers))
+	if(!LAZY_LENGTH(movement_handlers))
 		return FALSE
 	if(ispath(movement_handlers[1]))
 		return (handler_path in movement_handlers)
@@ -39,17 +39,17 @@ if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
 	. = new handler_path(src)
 
 	// If a handler_path_to_add_before was given, attempt to find it and insert our handler just before it
-	if(handler_path_to_add_before && LAZYLEN(movement_handlers))
+	if(handler_path_to_add_before && LAZY_LENGTH(movement_handlers))
 		var/index = 0
 		for(var/handler in movement_handlers)
 			index++
 			var/datum/H = handler
 			if(H.type == handler_path_to_add_before)
-				LAZYINSERT(movement_handlers, ., index)
+				LAZY_INSERT(movement_handlers, ., index)
 				return
 
 	// If no handler_path_to_add_after was given or found, add first
-	LAZYINSERT(movement_handlers, ., 1)
+	LAZY_INSERT(movement_handlers, ., 1)
 
 /atom/movable/proc/RemoveMovementHandler(var/handler_path)
 	INIT_MOVEMENT_HANDLERS
@@ -118,7 +118,7 @@ if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
 
 // Base
 /atom/movable/Destroy()
-	if(LAZYLEN(movement_handlers) && !ispath(movement_handlers[1]))
+	if(LAZY_LENGTH(movement_handlers) && !ispath(movement_handlers[1]))
 		QDEL_NULL_LIST(movement_handlers)
 	. = ..()
 

--- a/code/datums/repositories/sound_channels.dm
+++ b/code/datums/repositories/sound_channels.dm
@@ -15,7 +15,7 @@ GLOBAL_VAR_INIT(admin_sound_channel, GLOB.sound_channels.RequestChannel("ADMIN_F
 
 /repository/sound_channels/proc/RequestChannel(var/key)
 	. = RequestChannels(key, 1)
-	return LAZYLEN(.) && .[1]
+	return LAZY_LENGTH(.) && .[1]
 
 /repository/sound_channels/proc/RequestChannels(var/key, var/amount)
 	if(!key)
@@ -35,7 +35,7 @@ GLOBAL_VAR_INIT(admin_sound_channel, GLOB.sound_channels.RequestChannel("ADMIN_F
 		CRASH("Unable to supply the requested amount of channels: [key] - Expected [amount], was [length(.)]")
 
 	for(var/channel in .)
-		LAZYSET(keys_by_channel, "[channel]", key)
+		LAZY_SET(keys_by_channel, "[channel]", key)
 	return .
 
 /repository/sound_channels/proc/ReleaseChannel(var/channel)
@@ -43,5 +43,5 @@ GLOBAL_VAR_INIT(admin_sound_channel, GLOB.sound_channels.RequestChannel("ADMIN_F
 
 /repository/sound_channels/proc/ReleaseChannels(var/list/channels)
 	for(var/channel in channels)
-		LAZYREMOVE(keys_by_channel, "[channel]")
+		LAZY_REMOVE(keys_by_channel, "[channel]")
 		available_channels.Push(channel)

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -94,7 +94,7 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 			if(culture && prob(culture.subversive_potential))
 				dudes += man
 		dudes -= traitor_mob
-	if(LAZYLEN(dudes))
+	if(LAZY_LENGTH(dudes))
 		var/mob/living/carbon/human/M = pick(dudes)
 		to_chat(traitor_mob, "We have received credible reports that [M.real_name] might be willing to help our cause. If you need assistance, consider contacting them.")
 		traitor_mob.mind.store_memory("<b>Potential Collaborator</b>: [M.real_name]")

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -283,7 +283,7 @@ var/list/mob/living/forced_ambiance_list = new
 			sound_to(L, sound(null, channel = 2))
 
 	if(L.lastarea != src)
-		if(LAZYLEN(forced_ambience))
+		if(LAZY_LENGTH(forced_ambience))
 			forced_ambiance_list |= L
 			L.playsound_local(T,sound(pick(forced_ambience), repeat = 1, wait = 0, volume = 25, channel = GLOB.lobby_sound_channel))
 		else	//stop any old area's forced ambience, and try to play our non-forced ones

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -168,7 +168,7 @@
 		taking_matter = eating.matter
 
 	var/found_useful_mat
-	if(LAZYLEN(taking_matter))
+	if(LAZY_LENGTH(taking_matter))
 		for(var/material in taking_matter)
 			if(!isnull(stored_material[material]) && !isnull(storage_capacity[material]))
 				found_useful_mat = TRUE

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -183,7 +183,7 @@
 /obj/machinery/computer/apc_control/proc/log_activity(log_text)
 	if(!should_log)
 		return
-	LAZYADD(logs, "([station_time_timestamp()]): [auth_id] [log_text]")
+	LAZY_ADD(logs, "([station_time_timestamp()]): [auth_id] [log_text]")
 
 /obj/machinery/computer/apc_control/proc/restore_comp()
 	obj_flags &= ~EMAGGED

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -62,18 +62,18 @@
 	var/area/A = get_area(src)
 	ASSERT(istype(A))
 
-	LAZYADD(A.all_doors, src)
+	LAZY_ADD(A.all_doors, src)
 	areas_added = list(A)
 
 	for(var/direction in GLOB.cardinal)
 		A = get_area(get_step(src,direction))
 		if(istype(A) && !(A in areas_added))
-			LAZYADD(A.all_doors, src)
+			LAZY_ADD(A.all_doors, src)
 			areas_added += A
 
 /obj/machinery/door/firedoor/Destroy()
 	for(var/area/A in areas_added)
-		LAZYREMOVE(A.all_doors, src)
+		LAZY_REMOVE(A.all_doors, src)
 	. = ..()
 
 /obj/machinery/door/firedoor/get_material()

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -17,7 +17,7 @@ client
 	if(!GLOB.end_titles)
 		GLOB.end_titles = generate_titles()
 
-	LAZYINITLIST(credits)
+	LAZY_INIT(credits)
 
 	if(mob)
 		mob.overlay_fullscreen("fishbed",/obj/screen/fullscreen/fishbed)
@@ -87,7 +87,7 @@ client
 	var/client/P = parent
 	if(parent)
 		P.screen -= src
-	LAZYREMOVE(P.credits, src)
+	LAZY_REMOVE(P.credits, src)
 	parent = null
 	return ..()
 

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -169,7 +169,7 @@ var/global/list/image/splatter_cache=list()
 
 /obj/effect/decal/cleanable/blood/writing/New()
 	..()
-	if(LAZYLEN(random_icon_states))
+	if(LAZY_LENGTH(random_icon_states))
 		for(var/obj/effect/decal/cleanable/blood/writing/W in loc)
 			random_icon_states.Remove(W.icon_state)
 		icon_state = pick(random_icon_states)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -180,7 +180,7 @@
 		else
 			desc_comp += "No tech origins detected.<BR>"
 
-		if(LAZYLEN(matter))
+		if(LAZY_LENGTH(matter))
 			desc_comp += "<span class='notice'>Extractable materials:</span><BR>"
 			for(var/mat in matter)
 				desc_comp += "[SSmaterials.get_material_by_name(mat)]<BR>"

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -14,7 +14,7 @@
 	var/list/footstep_sounds	//footstep sounds when stepped on
 
 /obj/structure/proc/get_footstep_sound()
-	if(LAZYLEN(footstep_sounds)) return pick(footstep_sounds)
+	if(LAZY_LENGTH(footstep_sounds)) return pick(footstep_sounds)
 
 /obj/structure/Destroy()
 	var/turf/T = get_turf(src)

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -271,7 +271,7 @@
 
 	if(W.force && (W.damtype == "fire" || W.damtype == "brute"))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		visible_message("<span class='danger'>\The [src] has been [LAZYLEN(W.attack_verb) ? pick(W.attack_verb) : "attacked"] with \the [W] by \the [user]!</span>")
+		visible_message("<span class='danger'>\The [src] has been [LAZY_LENGTH(W.attack_verb) ? pick(W.attack_verb) : "attacked"] with \the [W] by \the [user]!</span>")
 		take_damage(W.force)
 		return
 	. = ..()

--- a/code/game/objects/structures/under_wardrobe.dm
+++ b/code/game/objects/structures/under_wardrobe.dm
@@ -25,9 +25,9 @@
 
 		audible_message(message, WARDROBE_BLIND_MESSAGE(user))
 
-		var/number_of_underwear = LAZYACCESS(amount_of_underwear_by_id_card, id) - 1
+		var/number_of_underwear = LAZY_ACCESS(amount_of_underwear_by_id_card, id) - 1
 		if(number_of_underwear)
-			LAZYSET(amount_of_underwear_by_id_card, id, number_of_underwear)
+			LAZY_SET(amount_of_underwear_by_id_card, id, number_of_underwear)
 			GLOB.destroyed_event.register(id, src, /obj/structure/undies_wardrobe/proc/remove_id_card)
 		else
 			remove_id_card(id)
@@ -36,7 +36,7 @@
 		..()
 
 /obj/structure/undies_wardrobe/proc/remove_id_card(var/id_card)
-	LAZYREMOVE(amount_of_underwear_by_id_card, id_card)
+	LAZY_REMOVE(amount_of_underwear_by_id_card, id_card)
 	GLOB.destroyed_event.unregister(id_card, src, /obj/structure/undies_wardrobe/proc/remove_id_card)
 
 /obj/structure/undies_wardrobe/attack_hand(var/mob/user)
@@ -50,7 +50,7 @@
 
 	var/dat = list()
 	dat += "<b>Underwear</b><br><hr>"
-	dat += "You may claim [id ? length(GLOB.underwear.categories) - LAZYACCESS(amount_of_underwear_by_id_card, id) : 0] more article\s this shift.<br><br>"
+	dat += "You may claim [id ? length(GLOB.underwear.categories) - LAZY_ACCESS(amount_of_underwear_by_id_card, id) : 0] more article\s this shift.<br><br>"
 	dat += "<b>Available Categories</b><br><hr>"
 	for(var/datum/category_group/underwear/UWC in GLOB.underwear.categories)
 		dat += "[UWC.name] <a href='?src=[REF(src)];select_underwear=[UWC.name]'>(Select)</a><br>"
@@ -97,11 +97,11 @@
 			audible_message("No ID card detected. Unable to acquire your underwear quota for this shift.", WARDROBE_BLIND_MESSAGE(H))
 			return
 
-		var/current_quota = LAZYACCESS(amount_of_underwear_by_id_card, id)
+		var/current_quota = LAZY_ACCESS(amount_of_underwear_by_id_card, id)
 		if(current_quota >= length(GLOB.underwear.categories))
 			audible_message("You have already used up your underwear quota for this shift. Please return previously acquired items to increase it.", WARDROBE_BLIND_MESSAGE(H))
 			return
-		LAZYSET(amount_of_underwear_by_id_card, id, ++current_quota)
+		LAZY_SET(amount_of_underwear_by_id_card, id, ++current_quota)
 
 		var/obj/UW = UWI.create_underwear(metadata_list)
 		UW.forceMove(loc)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -886,7 +886,7 @@ var/list/admin_verbs_mentor = list(
 			if(!job.is_position_available())
 				jobs["[job.title] - [submap.name]"] = job
 
-	if(!LAZYLEN(jobs))
+	if(!LAZY_LENGTH(jobs))
 		to_chat(usr, "There are no fully staffed offsite jobs.")
 		return
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -609,7 +609,7 @@
 	// Channels
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
 		var/list/channels = decls_repository.get_decls_of_subtype(/decl/communication_channel)
-		jobs += "<tr bgcolor='ccccff'><th colspan='[LAZYLEN(channels)]'>Channel Bans</th></tr><tr align='center'>"
+		jobs += "<tr bgcolor='ccccff'><th colspan='[LAZY_LENGTH(channels)]'>Channel Bans</th></tr><tr align='center'>"
 		for(var/channel_type in channels)
 			var/decl/communication_channel/channel = channels[channel_type]
 			if(jobban_isbanned(M, channel.name))

--- a/code/modules/alarm/alarm_handler.dm
+++ b/code/modules/alarm/alarm_handler.dm
@@ -31,7 +31,7 @@
 
 	alarms |= existing
 	alarms_assoc[origin] = existing
-	LAZYDISTINCTADD(alarms_by_z["[existing.alarm_z()]"], existing)
+	LAZY_ADD_UNIQUE(alarms_by_z["[existing.alarm_z()]"], existing)
 	if(new_alarm)
 		alarms = dd_sortedObjectList(alarms)
 		on_alarm_change(existing, ALARM_RAISED)

--- a/code/modules/client/preference_setup/background/01_culture.dm
+++ b/code/modules/client/preference_setup/background/01_culture.dm
@@ -32,7 +32,7 @@
 	for(var/token in tokens)
 		var/list/_cultures
 		GET_ALLOWED_VALUES(_cultures, token)
-		if(!LAZYLEN(_cultures))
+		if(!LAZY_LENGTH(_cultures))
 			pref.cultural_info[token] = GLOB.using_map.default_cultural_info[token]
 		else
 			var/current_value = pref.cultural_info[token]

--- a/code/modules/client/preference_setup/background/02_language.dm
+++ b/code/modules/client/preference_setup/background/02_language.dm
@@ -24,7 +24,7 @@
 	. = list()
 	. += "<b>Languages</b><br>"
 	var/list/show_langs = get_language_text()
-	if(LAZYLEN(show_langs))
+	if(LAZY_LENGTH(show_langs))
 		for(var/lang in show_langs)
 			. += lang
 	else
@@ -46,7 +46,7 @@
 
 		sanitize_alt_languages()
 		var/list/available_languages = allowed_languages - free_languages
-		if(!LAZYLEN(available_languages))
+		if(!LAZY_LENGTH(available_languages))
 			alert(user, "There are no additional languages available to select.")
 		else
 			var/new_lang = input(user, "Select an additional language", "Character Generation", null) as null|anything in available_languages
@@ -67,11 +67,11 @@
 		var/decl/cultural_info/culture = SSculture.get_culture(pref.cultural_info[thing])
 		if(istype(culture))
 			var/list/langs = culture.get_spoken_languages()
-			if(LAZYLEN(langs))
+			if(LAZY_LENGTH(langs))
 				for(var/checklang in langs)
 					free_languages[checklang] =    TRUE
 					allowed_languages[checklang] = TRUE
-			if(LAZYLEN(culture.secondary_langs))
+			if(LAZY_LENGTH(culture.secondary_langs))
 				for(var/checklang in culture.secondary_langs)
 					allowed_languages[checklang] = TRUE
 
@@ -96,7 +96,7 @@
 		var/datum/language/lang = all_languages[L]
 		if(!lang || !is_allowed_language(preference_mob, lang))
 			pref.alternate_languages -= L
-	if(LAZYLEN(free_languages))
+	if(LAZY_LENGTH(free_languages))
 		for(var/lang in free_languages)
 			pref.alternate_languages -= lang
 			pref.alternate_languages.Insert(1, lang)
@@ -107,15 +107,15 @@
 
 /datum/category_item/player_setup_item/background/languages/proc/get_language_text()
 	sanitize_alt_languages()
-	if(LAZYLEN(pref.alternate_languages))
+	if(LAZY_LENGTH(pref.alternate_languages))
 		for(var/i = 1 to pref.alternate_languages.len)
 			var/lang = pref.alternate_languages[i]
 			if(free_languages[lang])
-				LAZYADD(., "- [lang] (required).<br>")
+				LAZY_ADD(., "- [lang] (required).<br>")
 			else
-				LAZYADD(., "- [lang] <a href='?src=[REF(src)];remove_language=[i]'>Remove.</a><br>")
+				LAZY_ADD(., "- [lang] <a href='?src=[REF(src)];remove_language=[i]'>Remove.</a><br>")
 	if(pref.alternate_languages.len < MAX_LANGUAGES)
 		var/remaining_langs = MAX_LANGUAGES - pref.alternate_languages.len
-		LAZYADD(., "- <a href='?src=[REF(src)];add_language=1'>add</a> ([remaining_langs] remaining)<br>")
+		LAZY_ADD(., "- <a href='?src=[REF(src)];add_language=1'>add</a> ([remaining_langs] remaining)<br>")
 
 #undef MAX_LANGUAGES

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -138,14 +138,14 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		last_descriptors = pref.body_descriptors.Copy()
 	pref.body_descriptors = list()
 
-	if(LAZYLEN(mob_species.descriptors))
+	if(LAZY_LENGTH(mob_species.descriptors))
 		for(var/entry in mob_species.descriptors)
 			var/datum/mob_descriptor/descriptor = mob_species.descriptors[entry]
 			if(istype(descriptor))
 				if(isnull(last_descriptors[entry]))
 					pref.body_descriptors[entry] = descriptor.default_value // Species datums have initial default value.
 				else
-					pref.body_descriptors[entry] = Clamp(last_descriptors[entry], 1, LAZYLEN(descriptor.standalone_value_descriptors))
+					pref.body_descriptors[entry] = Clamp(last_descriptors[entry], 1, LAZY_LENGTH(descriptor.standalone_value_descriptors))
 
 	if(!pref.bgstate || !(pref.bgstate in pref.bgstate_options))
 		pref.bgstate = "000"
@@ -269,7 +269,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	else
 		. += "<br><br>"
 
-	if(LAZYLEN(pref.body_descriptors))
+	if(LAZY_LENGTH(pref.body_descriptors))
 		. += "<table>"
 		for(var/entry in pref.body_descriptors)
 			var/datum/mob_descriptor/descriptor = mob_species.descriptors[entry]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -284,7 +284,7 @@ datum/preferences
 	character.gen_record = gen_record
 	character.exploit_record = exploit_record
 
-	if(LAZYLEN(character.descriptors))
+	if(LAZY_LENGTH(character.descriptors))
 		for(var/entry in body_descriptors)
 			character.descriptors[entry] = body_descriptors[entry]
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -519,7 +519,7 @@
 			species_icon =  sprite_sheets[wearer.species.get_bodytype(wearer)]
 		mob_icon = image("icon" = species_icon, "icon_state" = "[icon_state]")
 
-	if(equipment_overlay_icon && LAZYLEN(installed_modules))
+	if(equipment_overlay_icon && LAZY_LENGTH(installed_modules))
 		for(var/obj/item/rig_module/module in installed_modules)
 			if(module.suit_overlay)
 				chest.overlays += image("icon" = equipment_overlay_icon, "icon_state" = "[module.suit_overlay]", "dir" = SOUTH)
@@ -539,7 +539,7 @@
 	if(slot != slot_back_str || offline)
 		return ret
 
-	if(equipment_overlay_icon && LAZYLEN(installed_modules))
+	if(equipment_overlay_icon && LAZY_LENGTH(installed_modules))
 		for(var/obj/item/rig_module/module in installed_modules)
 			if(module.suit_overlay)
 				ret.overlays += image("icon" = equipment_overlay_icon, "icon_state" = "[module.suit_overlay]")

--- a/code/modules/culture_descriptor/_culture.dm
+++ b/code/modules/culture_descriptor/_culture.dm
@@ -21,19 +21,19 @@
 		name_language = default_language
 
 	// Remove any overlap for the sake of presentation.
-	if(LAZYLEN(additional_langs))
+	if(LAZY_LENGTH(additional_langs))
 		additional_langs -= language
 		additional_langs -= name_language
 		additional_langs -= default_language
-		UNSETEMPTY(additional_langs)
+		UNSET_EMPTY(additional_langs)
 
-	if(LAZYLEN(secondary_langs))
+	if(LAZY_LENGTH(secondary_langs))
 		secondary_langs -= language
 		secondary_langs -= name_language
 		secondary_langs -= default_language
-		if(LAZYLEN(additional_langs))
+		if(LAZY_LENGTH(additional_langs))
 			secondary_langs -= additional_langs
-		UNSETEMPTY(secondary_langs)
+		UNSET_EMPTY(secondary_langs)
 
 	..()
 
@@ -78,9 +78,9 @@
 /decl/cultural_info/proc/get_text_details()
 	. = list()
 	var/list/spoken_langs = get_spoken_languages()
-	if(LAZYLEN(spoken_langs))
+	if(LAZY_LENGTH(spoken_langs))
 		. += "<b>Language(s):</b> [english_list(spoken_langs)]."
-	if(LAZYLEN(secondary_langs))
+	if(LAZY_LENGTH(secondary_langs))
 		. += "<b>Optional language(s):</b> [english_list(secondary_langs)]."
 	if(!isnull(economic_power))
 		. += "<b>Economic power:</b> [round(100 * economic_power)]%"
@@ -90,4 +90,4 @@
 	if(language)                  . |= language
 	if(default_language)          . |= default_language
 	if(name_language)             . |= name_language
-	if(LAZYLEN(additional_langs)) . |= additional_langs
+	if(LAZY_LENGTH(additional_langs)) . |= additional_langs

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -109,12 +109,12 @@ obj/item/clothing/var/gunshot_residue
 
 /atom/proc/transfer_fingerprints_to(var/atom/A)
 	if(fingerprints)
-		LAZYDISTINCTADD(A.fingerprints, fingerprints)
+		LAZY_ADD_UNIQUE(A.fingerprints, fingerprints)
 	if(fingerprintshidden)
-		LAZYDISTINCTADD(A.fingerprintshidden, fingerprintshidden)
+		LAZY_ADD_UNIQUE(A.fingerprintshidden, fingerprintshidden)
 		A.fingerprintslast = fingerprintslast
 	if(suit_fibers)
-		LAZYDISTINCTADD(A.suit_fibers, suit_fibers)
+		LAZY_ADD_UNIQUE(A.suit_fibers, suit_fibers)
 	if(blood_DNA)
 		A.blood_DNA |= blood_DNA
 
@@ -122,7 +122,7 @@ obj/item/clothing/var/gunshot_residue
 	..()
 	if(istype(A,/obj/item) && trace_DNA)
 		var/obj/item/I = A
-		LAZYDISTINCTADD(I.trace_DNA, trace_DNA)
+		LAZY_ADD_UNIQUE(I.trace_DNA, trace_DNA)
 
 /obj/item/clothing/transfer_fingerprints_to(var/atom/A)
 	..()
@@ -171,7 +171,7 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 	if(M.isSynthetic())
 		return
 	if(istype(M.dna))
-		LAZYDISTINCTADD(trace_DNA, M.dna.unique_enzymes)
+		LAZY_ADD_UNIQUE(trace_DNA, M.dna.unique_enzymes)
 
 /mob/proc/get_full_print()
 	return FALSE

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -71,9 +71,9 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 	// The proceeding mess will almost definitely break if error messages are ever changed
 	var/list/splitlines = splittext(E.desc, "\n")
 	var/list/desclines = list()
-	if(LAZYLEN(splitlines) > ERROR_USEFUL_LEN) // If there aren't at least three lines, there's no info
+	if(LAZY_LENGTH(splitlines) > ERROR_USEFUL_LEN) // If there aren't at least three lines, there's no info
 		for(var/line in splitlines)
-			if(LAZYLEN(line) < 3 || findtext(line, "source file:") || findtext(line, "usr.loc:"))
+			if(LAZY_LENGTH(line) < 3 || findtext(line, "source file:") || findtext(line, "usr.loc:"))
 				continue
 			if(findtext(line, "usr:"))
 				if(usrinfo)

--- a/code/modules/events/maint_drones.dm
+++ b/code/modules/events/maint_drones.dm
@@ -4,7 +4,7 @@
 
 	var/list/spots = get_infestation_turfs()
 	for(var/i = 0 to groups)
-		if(!LAZYLEN(spots))
+		if(!LAZY_LENGTH(spots))
 			break
 		var/turf/T = pick(spots)
 		for(var/j = 0 to drons)

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -329,7 +329,7 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 	if(members[index] != /area/template_noop)
 		is_not_noop = TRUE
 		var/list/attr = members_attributes[index]
-		if (LAZYLEN(attr))
+		if (LAZY_LENGTH(attr))
 			GLOB._preloader.setup(attr)//preloader for assigning  set variables on atom creation
 		var/atype = members[index]
 		var/atom/instance
@@ -396,7 +396,7 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 
 //Instance an atom at (x,y,z) and gives it the variables in attributes
 /dmm_suite/proc/instance_atom(path,list/attributes, turf/crds, no_changeturf)
-	if (LAZYLEN(attributes))
+	if (LAZY_LENGTH(attributes))
 		GLOB._preloader.setup(attributes, path)
 
 	if(crds)
@@ -511,7 +511,7 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 	var/target_path
 
 /dmm_suite/preloader/proc/setup(list/the_attributes, path)
-	if(LAZYLEN(the_attributes))
+	if(LAZY_LENGTH(the_attributes))
 		GLOB.use_preloader = TRUE
 		attributes = the_attributes
 		target_path = path

--- a/code/modules/mining/machinery/mineral_processor.dm
+++ b/code/modules/mining/machinery/mineral_processor.dm
@@ -40,7 +40,7 @@
 		for(var/obj/item/weapon/ore/I in recursive_content_check(input_turf, sight_check = FALSE, include_mobs = FALSE))
 			if(QDELETED(I) || !I.simulated || I.anchored)
 				continue
-			if(LAZYLEN(I.matter))
+			if(LAZY_LENGTH(I.matter))
 				for(var/o_material in I.matter)
 					if(!isnull(ores_stored[o_material]))
 						ores_stored[o_material] += I.matter[o_material]
@@ -83,7 +83,7 @@
 				result++
 
 		// Try to make any available alloys.
-		if(LAZYLEN(attempt_to_alloy))
+		if(LAZY_LENGTH(attempt_to_alloy))
 
 			var/list/making_alloys = list()
 			for(var/thing in SSmaterials.alloy_products)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -239,7 +239,7 @@ var/list/mining_floors = list()
 	name = "mineral deposit"
 
 /turf/simulated/mineral/random/New(var/newloc, var/mineral_name, var/default_mineral_list = GLOB.weighted_minerals_sparse)
-	if(!mineral_name && LAZYLEN(default_mineral_list))
+	if(!mineral_name && LAZY_LENGTH(default_mineral_list))
 		mineral_name = pickweight(default_mineral_list)
 
 	if(!mineral && mineral_name)

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -160,20 +160,11 @@
 
 	return valid_species
 
-/mob/living/carbon/human/proc/generate_valid_hairstyles(var/check_gender = 1)
-	. = list()
-	var/list/hair_styles = species.get_hair_styles()
-	for(var/hair_style in hair_styles)
-		var/datum/sprite_accessory/S = hair_styles[hair_style]
-		if(check_gender)
-			if(gender == MALE && S.gender == FEMALE)
-				continue
-			if(gender == FEMALE && S.gender == MALE)
-				continue
-		.[hair_style] = S
+/mob/living/carbon/human/proc/generate_valid_hairstyles(check_gender = 1)
+	return species.get_hair_styles(check_gender && gender || PLURAL)
 
-/mob/living/carbon/human/proc/generate_valid_facial_hairstyles()
-	return species.get_facial_hair_styles(gender)
+/mob/living/carbon/human/proc/generate_valid_facial_hairstyles(check_gender = 1)
+	return species.get_facial_hair_styles(check_gender && gender || PLURAL)
 
 /mob/living/carbon/human/proc/force_update_limbs()
 	for(var/obj/item/organ/external/O in organs)

--- a/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
@@ -5,15 +5,15 @@
 */
 
 /mob/living/carbon/human/proc/show_descriptors_to(var/mob/user)
-	if(LAZYLEN(descriptors))
+	if(LAZY_LENGTH(descriptors))
 		if(user == src)
 			for(var/entry in descriptors)
 				var/datum/mob_descriptor/descriptor = species.descriptors[entry]
-				LAZYADD(., "[descriptor.get_first_person_message_start()] [descriptor.get_standalone_value_descriptor(descriptors[entry])].")
+				LAZY_ADD(., "[descriptor.get_first_person_message_start()] [descriptor.get_standalone_value_descriptor(descriptors[entry])].")
 		else
 			for(var/entry in descriptors)
 				var/datum/mob_descriptor/descriptor = species.descriptors[entry]
-				LAZYADD(., descriptor.get_comparative_value_descriptor(descriptors[entry], user, src))
+				LAZY_ADD(., descriptor.get_comparative_value_descriptor(descriptors[entry], user, src))
 
 /datum/mob_descriptor
 	var/name                                       // String ident.
@@ -32,9 +32,9 @@
 		chargen_label = name
 	if(!chargen_value_descriptors)
 		chargen_value_descriptors = list()
-		for(var/i = 1 to LAZYLEN(standalone_value_descriptors))
+		for(var/i = 1 to LAZY_LENGTH(standalone_value_descriptors))
 			chargen_value_descriptors[standalone_value_descriptors[i]] = i
-	default_value = Ceiling(LAZYLEN(standalone_value_descriptors) * 0.5)
+	default_value = Ceiling(LAZY_LENGTH(standalone_value_descriptors) * 0.5)
 	..()
 
 /datum/mob_descriptor/proc/get_third_person_message_start(var/datum/gender/my_gender)
@@ -46,7 +46,7 @@
 /datum/mob_descriptor/proc/get_standalone_value_descriptor(var/check_value)
 	if(isnull(check_value))
 		check_value = default_value
-	if(check_value && LAZYLEN(standalone_value_descriptors) >= check_value)
+	if(check_value && LAZY_LENGTH(standalone_value_descriptors) >= check_value)
 		return standalone_value_descriptors[check_value]
 
 // Build a species-specific descriptor string.
@@ -65,7 +65,7 @@
 	if(variance < 1)
 		. = "[.], [get_comparative_value_string_equivalent(raw_value, my_gender, other_gender)]"
 	else
-		variance = variance / LAZYLEN(standalone_value_descriptors)
+		variance = variance / LAZY_LENGTH(standalone_value_descriptors)
 		if(my_value < comparing_value)
 			. = "[.], [get_comparative_value_string_smaller(variance, my_gender, other_gender)]"
 		else if(my_value > comparing_value)
@@ -83,7 +83,7 @@
 	var/comparing_value
 	if(ishuman(observer))
 		var/mob/living/carbon/human/human_observer = observer
-		if(LAZYLEN(human_observer.descriptors) && !isnull(human_observer.species.descriptors[name]) && !isnull(human_observer.descriptors[name]))
+		if(LAZY_LENGTH(human_observer.descriptors) && !isnull(human_observer.species.descriptors[name]) && !isnull(human_observer.descriptors[name]))
 			var/datum/mob_descriptor/obs_descriptor = human_observer.species.descriptors[name]
 			comparing_value = human_observer.descriptors[name] + obs_descriptor.comparison_offset
 
@@ -97,11 +97,11 @@
 	return comparative_value_descriptor_equivalent
 
 /datum/mob_descriptor/proc/get_comparative_value_string_smaller(var/value, var/datum/gender/my_gender, var/datum/gender/other_gender)
-	var/maxval = LAZYLEN(comparative_value_descriptors_smaller)
+	var/maxval = LAZY_LENGTH(comparative_value_descriptors_smaller)
 	value = Clamp(Ceiling(value * maxval), 1, maxval)
 	return comparative_value_descriptors_smaller[value]
 
 /datum/mob_descriptor/proc/get_comparative_value_string_larger(var/value, var/datum/gender/my_gender, var/datum/gender/other_gender)
-	var/maxval = LAZYLEN(comparative_value_descriptors_larger)
+	var/maxval = LAZY_LENGTH(comparative_value_descriptors_larger)
 	value = Clamp(Ceiling(value * maxval), 1, maxval)
 	return comparative_value_descriptors_larger[value]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1029,10 +1029,10 @@
 	pixel_x = default_pixel_x
 	pixel_y = default_pixel_y
 
-	if(LAZYLEN(descriptors))
+	if(LAZY_LENGTH(descriptors))
 		descriptors = null
 
-	if(LAZYLEN(species.descriptors))
+	if(LAZY_LENGTH(species.descriptors))
 		descriptors = list()
 		for(var/desctype in species.descriptors)
 			var/datum/mob_descriptor.descriptor = species.descriptors[desctype]
@@ -1117,7 +1117,7 @@
 		var/datum/language/lang = thing
 		add_language(lang.name)
 
-	if(LAZYLEN(default_languages) && isnull(default_language))
+	if(LAZY_LENGTH(default_languages) && isnull(default_language))
 		default_language = default_languages[1]
 
 /mob/living/carbon/human/proc/bloody_doodle()

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -245,10 +245,10 @@
 // Returns true if, and only if, the human has gone from uncloaked to cloaked
 /mob/living/carbon/human/proc/add_cloaking_source(var/datum/cloaking_source)
 	var/has_uncloaked = clean_cloaking_sources()
-	LAZYDISTINCTADD(cloaking_sources, weakref(cloaking_source))
+	LAZY_ADD_UNIQUE(cloaking_sources, weakref(cloaking_source))
 
 	// We don't present the cloaking message if the human was already cloaked just before cleanup.
-	if(!has_uncloaked && LAZYLEN(cloaking_sources) == 1)
+	if(!has_uncloaked && LAZY_LENGTH(cloaking_sources) == 1)
 		update_icons()
 		src.visible_message("<span class='warning'>\The [src] seems to disappear before your eyes!</span>", "<span class='notice'>You feel completely invisible.</span>")
 		return TRUE
@@ -259,11 +259,11 @@
 
 // Returns true if, and only if, the human has gone from cloaked to uncloaked
 /mob/living/carbon/human/proc/remove_cloaking_source(var/datum/cloaking_source)
-	var/was_cloaked = LAZYLEN(cloaking_sources)
+	var/was_cloaked = LAZY_LENGTH(cloaking_sources)
 	clean_cloaking_sources()
-	LAZYREMOVE(cloaking_sources, weakref(cloaking_source))
+	LAZY_REMOVE(cloaking_sources, weakref(cloaking_source))
 
-	if(was_cloaked && !LAZYLEN(cloaking_sources))
+	if(was_cloaked && !LAZY_LENGTH(cloaking_sources))
 		update_icons()
 		visible_message(CLOAK_APPEAR_OTHER, CLOAK_APPEAR_SELF)
 		return TRUE
@@ -274,14 +274,14 @@
 	if(clean_cloaking_sources())
 		update_icons()
 		visible_message(CLOAK_APPEAR_OTHER, CLOAK_APPEAR_SELF)
-	return LAZYLEN(cloaking_sources)
+	return LAZY_LENGTH(cloaking_sources)
 
 #undef CLOAK_APPEAR_OTHER
 #undef CLOAK_APPEAR_SELF
 
 // Returns true if the human is cloaked by the given source
 /mob/living/carbon/human/proc/is_cloaked_by(var/cloaking_source)
-	return LAZYISIN(cloaking_sources, weakref(cloaking_source))
+	return LAZY_IS_IN(cloaking_sources, weakref(cloaking_source))
 
 // Returns true if this operation caused the mob to go from cloaked to uncloaked
 /mob/living/carbon/human/proc/clean_cloaking_sources()
@@ -299,5 +299,5 @@
 		var/rogue_entries_as_string = jointext(map(rogue_entries, /proc/log_info_line), ", ")
 		crash_with("[log_info_line(src)] - Following cloaking entries were removed during cleanup: [rogue_entries_as_string]")
 
-	UNSETEMPTY(cloaking_sources)
+	UNSET_EMPTY(cloaking_sources)
 	return !cloaking_sources // If cloaking_sources wasn't initially null but is now, we've uncloaked

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -169,7 +169,7 @@ Please contact me on #coderbus IRC. ~Carn x
 		if(lying && (species.prone_overlay_offset[1] || species.prone_overlay_offset[2]))
 			M.Translate(species.prone_overlay_offset[1], species.prone_overlay_offset[2])
 
-		for(var/i = 1 to LAZYLEN(visible_overlays))
+		for(var/i = 1 to LAZY_LENGTH(visible_overlays))
 			var/entry = visible_overlays[i]
 			if(istype(entry, /image))
 				var/image/overlay = entry

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -765,12 +765,12 @@ default behaviour is:
 		overlays |= auras
 
 /mob/living/proc/add_aura(var/obj/aura/aura)
-	LAZYDISTINCTADD(auras,aura)
+	LAZY_ADD_UNIQUE(auras,aura)
 	update_icons()
 	return 1
 
 /mob/living/proc/remove_aura(var/obj/aura/aura)
-	LAZYREMOVE(auras,aura)
+	LAZY_REMOVE(auras,aura)
 	update_icons()
 	return 1
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -103,7 +103,6 @@ var/list/ai_verbs_default = list(
 	var/multitool_mode = 0
 
 	var/default_ai_icon = /datum/ai_icon/blue
-	var/static/list/custom_ai_icons_by_ckey_and_name
 
 /mob/living/silicon/ai/proc/add_ai_verbs()
 	src.verbs |= ai_verbs_default
@@ -264,9 +263,6 @@ var/list/ai_verbs_default = list(
 		var/datum/ai_icon/ai_icon = all_ai_icons[ai_icon_type]
 		if(ai_icon.may_used_by_ai(src))
 			dd_insertObjectList(., ai_icon)
-
-	// Placing custom icons first to have them be at the top
-	. = LAZYACCESS(custom_ai_icons_by_ckey_and_name, "[ckey][real_name]") | .
 
 // this verb lets the ai see the stations manifest
 /mob/living/silicon/ai/proc/ai_roster()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -159,12 +159,12 @@
 
 		 // don't bother checking it twice if we got a supplied 0 val.
 		if(atmos_suitable)
-			if(LAZYLEN(min_gas))
+			if(LAZY_LENGTH(min_gas))
 				for(var/gas in min_gas)
 					if(environment.gas[gas] < min_gas[gas])
 						atmos_suitable = FALSE
 						break
-			if(atmos_suitable && LAZYLEN(max_gas))
+			if(atmos_suitable && LAZY_LENGTH(max_gas))
 				for(var/gas in max_gas)
 					if(environment.gas[gas] > max_gas[gas])
 						atmos_suitable = FALSE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -407,7 +407,7 @@
 		var/summary = job.get_join_link(client, "byond://?src=[REF(src)];SelectedJob=[job.title]", show_invalid_jobs)
 		if(summary && summary != "")
 			job_summaries += summary
-	if(LAZYLEN(job_summaries))
+	if(LAZY_LENGTH(job_summaries))
 		dat += job_summaries
 	else
 		dat += "No available positions."
@@ -424,7 +424,7 @@
 				var/summary = job.get_join_link(client, "byond://?src=[REF(submap)];joining=[REF(src)];join_as=[otherthing]", show_invalid_jobs)
 				if(summary && summary != "")
 					job_summaries += summary
-			if(LAZYLEN(job_summaries))
+			if(LAZY_LENGTH(job_summaries))
 				dat += job_summaries
 			else
 				dat += "No available positions."

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -442,7 +442,7 @@ This function completely restores a damaged organ to perfect condition.
 		owner.organs_by_name[organ_tag] = null
 		owner.organs_by_name -= organ_tag
 		while(null in owner.organs) owner.organs -= null
-	if(LAZYLEN(children))
+	if(LAZY_LENGTH(children))
 		for(var/obj/item/organ/external/E in children)
 			E.remove_rejuv()
 		children.Cut()
@@ -829,7 +829,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		disintegrate = DROPLIMB_BLUNT //splut
 
 	var/list/organ_msgs = get_droplimb_messages_for(disintegrate, clean)
-	if(LAZYLEN(organ_msgs) >= 3)
+	if(LAZY_LENGTH(organ_msgs) >= 3)
 		owner.visible_message("<span class='critical'>[organ_msgs[1]]</span>", \
 			"<span class='moderate'><b>[organ_msgs[2]]</b></span>", \
 			"<span class='danger'>[organ_msgs[3]]</span>")

--- a/code/modules/organs/internal/voice.dm
+++ b/code/modules/organs/internal/voice.dm
@@ -8,7 +8,7 @@
 /obj/item/organ/internal/voicebox/Initialize()
 	. = ..()
 	var/list/language_datums = list()
-	if(LAZYLEN(assists_languages))
+	if(LAZY_LENGTH(assists_languages))
 		for(var/L in assists_languages)
 			var/lang = all_languages[L]
 			if(lang) language_datums[lang] = TRUE

--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -34,7 +34,7 @@
 	if(victim in victims)
 		log_error("Multiple attempts to trigger the same event by [victim] detected.")
 		return
-	LAZYADD(victims, victim)
+	LAZY_ADD(victims, victim)
 	var/datum/event_meta/EM = new(difficulty, "Overmap event - [name]", event, add_to_queue = FALSE, is_one_shot = TRUE)
 	var/datum/event/E = new event(EM)
 	E.startWhen = 0
@@ -46,4 +46,4 @@
 	if(victims && victims[victim])
 		var/datum/event/E = victims[victim]
 		E.kill()
-		LAZYREMOVE(victims, victim)
+		LAZY_REMOVE(victims, victim)

--- a/code/modules/overmap/exoplanets/volcanic.dm
+++ b/code/modules/overmap/exoplanets/volcanic.dm
@@ -129,11 +129,11 @@
 	if(locate(/obj/structure/catwalk/) in src)
 		return
 	if(AM.is_burnable())
-		LAZYADD(victims, weakref(AM))
+		LAZY_ADD(victims, weakref(AM))
 		START_PROCESSING(SSobj, src)
 
 /turf/simulated/floor/exoplanet/lava/Exited(atom/movable/AM)
-	LAZYREMOVE(victims, weakref(AM))
+	LAZY_REMOVE(victims, weakref(AM))
 
 /turf/simulated/floor/exoplanet/lava/Process()
 	if(locate(/obj/structure/catwalk/) in src)
@@ -148,7 +148,7 @@
 		var/pressure = environment.return_pressure()
 		if(AM.lava_act(environment, 5000 + environment.temperature, pressure))
 			victims -= W
-	if(!LAZYLEN(victims))
+	if(!LAZY_LENGTH(victims))
 		return PROCESS_KILL
 
 /turf/simulated/floor/exoplanet/lava/get_footstep_sound()

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -60,7 +60,7 @@
 obj/effect/overmap/proc/add_landmark(obj/effect/shuttle_landmark/landmark, shuttle_name)
 	landmark.sector_set(src)
 	if(shuttle_name)
-		LAZYADD(restricted_waypoints[shuttle_name], landmark)
+		LAZY_ADD(restricted_waypoints[shuttle_name], landmark)
 	else
 		generic_waypoints += landmark
 

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -15,7 +15,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	linked = map_sectors["[z]"]
 
 /obj/machinery/computer/helm/Destroy()
-	if(LAZYLEN(viewers))
+	if(LAZY_LENGTH(viewers))
 		for(var/weakref/W in viewers)
 			var/M = W.resolve()
 			if(M)
@@ -60,7 +60,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		user.client.view = world.view + 4
 	GLOB.moved_event.register(user, src, /obj/machinery/computer/helm/proc/unlook)
 	GLOB.stat_set_event.register(user, src, /obj/machinery/computer/helm/proc/unlook)
-	LAZYDISTINCTADD(viewers, weakref(user))
+	LAZY_ADD_UNIQUE(viewers, weakref(user))
 
 /obj/machinery/computer/helm/proc/unlook(var/mob/user)
 	user.reset_view()
@@ -68,7 +68,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		user.client.view = world.view
 	GLOB.moved_event.unregister(user, src, /obj/machinery/computer/helm/proc/unlook)
 	GLOB.stat_set_event.unregister(user, src, /obj/machinery/computer/helm/proc/unlook)
-	LAZYREMOVE(viewers, weakref(user))
+	LAZY_REMOVE(viewers, weakref(user))
 
 /obj/machinery/computer/helm/ui_status(mob/user, datum/ui_state/state)
 	if(!linked)

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -16,7 +16,7 @@
 
 /obj/machinery/computer/sensors/Destroy()
 	sensors = null
-	if(LAZYLEN(viewers))
+	if(LAZY_LENGTH(viewers))
 		for(var/weakref/W in viewers)
 			var/M = W.resolve()
 			if(M)
@@ -114,7 +114,7 @@
 		user.client.view = world.view + 4
 	GLOB.moved_event.register(user, src, /obj/machinery/computer/sensors/proc/unlook)
 	GLOB.stat_set_event.register(user, src, /obj/machinery/computer/sensors/proc/unlook)
-	LAZYDISTINCTADD(viewers, weakref(user))
+	LAZY_ADD_UNIQUE(viewers, weakref(user))
 
 /obj/machinery/computer/sensors/proc/unlook(var/mob/user)
 	user.reset_view()
@@ -122,7 +122,7 @@
 		user.client.view = world.view
 	GLOB.moved_event.unregister(user, src, /obj/machinery/computer/sensors/proc/unlook)
 	GLOB.stat_set_event.unregister(user, src, /obj/machinery/computer/sensors/proc/unlook)
-	LAZYREMOVE(viewers, weakref(user))
+	LAZY_REMOVE(viewers, weakref(user))
 
 /obj/machinery/computer/sensors/Process()
 	..()

--- a/code/modules/persistence/persistence_datum.dm
+++ b/code/modules/persistence/persistence_datum.dm
@@ -76,7 +76,7 @@
 			if(!entry_line)
 				continue
 			var/list/tokens = splittext(entry_line, file_entry_split_character)
-			if(LAZYLEN(tokens) < tokens_per_line)
+			if(LAZY_LENGTH(tokens) < tokens_per_line)
 				continue
 			tokens = label_tokens(tokens)
 			if(!check_token_sanity(tokens))
@@ -90,5 +90,5 @@
 	for(var/thing in SSpersistence.tracking_values[type])
 		if(is_valid_entry(thing))
 			var/list/entry = compile_entry(thing)
-			if(LAZYLEN(entry) == tokens_per_line)
+			if(LAZY_LENGTH(entry) == tokens_per_line)
 				to_file(write_file, jointext(entry, file_entry_split_character))

--- a/code/modules/persistence/persistence_datum_filth.dm
+++ b/code/modules/persistence/persistence_datum_filth.dm
@@ -8,7 +8,7 @@
 
 /datum/persistent/filth/label_tokens(var/list/tokens)
 	var/list/labelled_tokens = ..()
-	labelled_tokens["path"] = text2path(tokens[LAZYLEN(labelled_tokens)+1])
+	labelled_tokens["path"] = text2path(tokens[LAZY_LENGTH(labelled_tokens)+1])
 	return labelled_tokens
 
 /datum/persistent/filth/is_valid_entry(var/atom/entry)
@@ -35,4 +35,4 @@
 
 /datum/persistent/filth/compile_entry(var/atom/entry)
 	. = ..()
-	LAZYADD(., "[get_entry_path(entry)]")
+	LAZY_ADD(., "[get_entry_path(entry)]")

--- a/code/modules/persistence/persistence_datum_graffiti.dm
+++ b/code/modules/persistence/persistence_datum_graffiti.dm
@@ -11,7 +11,7 @@
 
 /datum/persistent/graffiti/label_tokens(var/list/tokens)
 	var/list/labelled_tokens = ..()
-	var/entries = LAZYLEN(labelled_tokens)
+	var/entries = LAZY_LENGTH(labelled_tokens)
 	labelled_tokens["author"] =  tokens[entries+1]
 	labelled_tokens["message"] = tokens[entries+2]
 	return labelled_tokens
@@ -66,5 +66,5 @@
 /datum/persistent/graffiti/compile_entry(var/atom/entry, var/write_file)
 	. = ..()
 	var/obj/effect/decal/writing/save_graffiti = entry
-	LAZYADD(., "[save_graffiti.author || "unknown"]")
-	LAZYADD(., "[save_graffiti.message]")
+	LAZY_ADD(., "[save_graffiti.author || "unknown"]")
+	LAZY_ADD(., "[save_graffiti.message]")

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -88,7 +88,7 @@
 	switch(handle_casings)
 		if(EJECT_CASINGS) //eject casing onto ground.
 			chambered.forceMove(get_turf(src))
-			if(LAZYLEN(chambered.fall_sounds))
+			if(LAZY_LENGTH(chambered.fall_sounds))
 				playsound(loc, pick(chambered.fall_sounds), 50, 1)
 		if(CYCLE_CASINGS) //cycle the casing back to the end.
 			if(ammo_magazine)

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -33,7 +33,7 @@
 
 	if(chambered)//We have a shell in the chamber
 		chambered.forceMove(get_turf(src))//Eject casing
-		if(LAZYLEN(chambered.fall_sounds))
+		if(LAZY_LENGTH(chambered.fall_sounds))
 			playsound(loc, pick(chambered.fall_sounds), 50, 1)
 		chambered = null
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -208,7 +208,7 @@
 	if(result == PROJECTILE_FORCE_MISS)
 		if(!silenced)
 			target_mob.visible_message("<span class='notice'>\The [src] misses [target_mob] narrowly!</span>")
-			if(LAZYLEN(miss_sounds))
+			if(LAZY_LENGTH(miss_sounds))
 				playsound(target_mob.loc, pick(miss_sounds), 60, 1)
 		return 0
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -582,7 +582,7 @@
 	. = ..()
 	if(istype(M))
 		for(var/obj/item/organ/external/E in M.organs)
-			if(LAZYLEN(E.implants))
+			if(LAZY_LENGTH(E.implants))
 				for(var/obj/effect/spider/spider in E.implants)
 					if(prob(25))
 						E.implants -= spider

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -275,11 +275,11 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 				available_cultural_info[token] = list()
 			available_cultural_info[token] |= additional_available_cultural_info[token]
 
-		else if(!available_cultural_info || !LAZYLEN(available_cultural_info[token]))
+		else if(!available_cultural_info || !LAZY_LENGTH(available_cultural_info[token]))
 			var/list/map_systems = GLOB.using_map.available_cultural_info[token]
 			available_cultural_info[token] = map_systems.Copy()
 
-		if(LAZYLEN(available_cultural_info[token]) && !default_cultural_info[token])
+		if(LAZY_LENGTH(available_cultural_info[token]) && !default_cultural_info[token])
 			var/list/avail_systems = available_cultural_info[token]
 			default_cultural_info[token] = avail_systems[1]
 
@@ -291,7 +291,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	else
 		hud = new()
 
-	if(LAZYLEN(descriptors))
+	if(LAZY_LENGTH(descriptors))
 		var/list/descriptor_datums = list()
 		for(var/desctype in descriptors)
 			var/datum/mob_descriptor/descriptor = new desctype
@@ -629,24 +629,30 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		return 80
 	return 220
 
-/datum/species/proc/get_hair_styles()
-	var/list/L = hair_styles
+// Note: pass-by-reference
+/datum/species/proc/get_hair_styles(var/gender)
+	var/list/L = LAZY_ACCESS_ASSOC(hair_styles, gender)
 	if(!L)
 		L = list()
-		hair_styles = L
+		LAZY_SET(hair_styles, gender, L)
 		for(var/hairstyle in GLOB.hair_styles_list)
 			var/datum/sprite_accessory/S = GLOB.hair_styles_list[hairstyle]
+			if(gender == MALE && S.gender == FEMALE)
+				continue
+			if(gender == FEMALE && S.gender == MALE)
+				continue
 			if(!(get_bodytype() in S.species_allowed))
 				continue
 			ADD_SORTED(L, hairstyle, /proc/cmp_text_asc)
 			L[hairstyle] = S
 	return L
 
+// Note: pass-by-reference
 /datum/species/proc/get_facial_hair_styles(var/gender)
-	var/list/L = LAZYACCESS(facial_hair_styles, gender)
+	var/list/L = LAZY_ACCESS_ASSOC(facial_hair_styles, gender)
 	if(!L)
 		L = list()
-		LAZYSET(facial_hair_styles, gender, L)
+		LAZY_SET(facial_hair_styles, gender, L)
 		for(var/facialhairstyle in GLOB.facial_hair_styles_list)
 			var/datum/sprite_accessory/S = GLOB.facial_hair_styles_list[facialhairstyle]
 			if(gender == MALE && S.gender == FEMALE)
@@ -722,7 +728,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 					dat += "</br><b>Resistant to [kind].</b>"
 			dat += "</br><b>They breathe [gas_data.name[breath_type]].</b>"
 			dat += "</br><b>They exhale [gas_data.name[exhale_type]].</b>"
-			dat += "</br><b>[capitalize(english_list(poison_types))] [LAZYLEN(poison_types) == 1 ? "is" : "are"] poisonous to them.</b>"
+			dat += "</br><b>[capitalize(english_list(poison_types))] [LAZY_LENGTH(poison_types) == 1 ? "is" : "are"] poisonous to them.</b>"
 			dat += "</small>"
 		dat += "</td>"
 	dat += "</tr>"

--- a/code/modules/species/species_helpers.dm
+++ b/code/modules/species/species_helpers.dm
@@ -16,7 +16,7 @@ var/list/stored_shock_by_ref = list()
 /datum/species/proc/get_offset_overlay_image(var/spritesheet, var/mob_icon, var/mob_state, var/color, var/slot)
 
 	// If we don't actually need to offset this, don't bother with any of the generation/caching.
-	if(!spritesheet && equip_adjust.len && equip_adjust[slot] && LAZYLEN(equip_adjust[slot]))
+	if(!spritesheet && equip_adjust.len && equip_adjust[slot] && LAZY_LENGTH(equip_adjust[slot]))
 
 		// Check the cache for previously made icons.
 		var/image_key = "[mob_icon]-[mob_state]-[color]"

--- a/code/modules/submaps/submap_job.dm
+++ b/code/modules/submaps/submap_job.dm
@@ -26,7 +26,7 @@
 	if(minimum_character_age && (prefs.age < minimum_character_age))
 		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age].</span>")
 		return TRUE
-	if(LAZYLEN(whitelisted_species) && !(prefs.species in whitelisted_species))
+	if(LAZY_LENGTH(whitelisted_species) && !(prefs.species in whitelisted_species))
 		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as crew on \a [owner.archetype.descriptor].</span>")
 		return TRUE
 	if(prefs.species in blacklisted_species)

--- a/code/modules/submaps/submap_join.dm
+++ b/code/modules/submaps/submap_join.dm
@@ -39,7 +39,7 @@
 	if(!check_general_join_blockers(joining, job))
 		return
 
-	if(!LAZYLEN(job.spawnpoints))
+	if(!LAZY_LENGTH(job.spawnpoints))
 		to_chat(joining, "<span class='warning'>There are no available spawn points for that job.</span>")
 
 	var/turf/spawn_turf = get_turf(pick(job.spawnpoints))

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -309,6 +309,6 @@
 		if("setSharedState")
 			if(status != UI_INTERACTIVE)
 				return
-			LAZYINITLIST(src_object.tgui_shared_states)
+			LAZY_INIT(src_object.tgui_shared_states)
 			src_object.tgui_shared_states[href_list["key"]] = href_list["value"]
 			SStgui.update_uis(src_object)

--- a/code/modules/ui_modules/appearance_changer.dm
+++ b/code/modules/ui_modules/appearance_changer.dm
@@ -26,12 +26,12 @@
 		if("race")
 			if(can_change(APPEARANCE_RACE) && (params["race"] in valid_species))
 				if(owner.change_species(params["race"]))
-					cut_and_generate_data()
+					cut_data()
 					return TRUE
 		if("gender")
 			if(can_change(APPEARANCE_GENDER) && (params["gender"] in owner.species.genders))
 				if(owner.change_gender(params["gender"]))
-					cut_and_generate_data()
+					cut_data()
 					return TRUE
 		if("skin_tone")
 			if(can_change_skin_tone())
@@ -106,7 +106,8 @@
 		ui.open()
 
 /datum/ui_module/appearance_changer/ui_data(mob/user)
-	generate_data(check_whitelist, whitelist, blacklist)
+	generate_data()
+
 	var/list/data = host.initial_data()
 
 	data["specimen"] = owner.species.name
@@ -161,18 +162,18 @@
 /datum/ui_module/appearance_changer/proc/can_change_skin_color()
 	return owner && (flags & APPEARANCE_SKIN) && owner.species.appearance_flags & HAS_SKIN_COLOR
 
-/datum/ui_module/appearance_changer/proc/cut_and_generate_data()
-	// Making the assumption that the available species remain constant
-	valid_facial_hairstyles.Cut()
-	valid_facial_hairstyles.Cut()
-	generate_data()
+/datum/ui_module/appearance_changer/proc/cut_data()
+	// These previously called Cut()... on lists that were passed by reference...
+	// Bay coders give me trust issues sometimes.
+	valid_hairstyles = null
+	valid_facial_hairstyles = null
 
 /datum/ui_module/appearance_changer/proc/generate_data()
 	if(!owner)
 		return
-	if(!valid_species.len)
+	if(!LAZY_LENGTH(valid_species))
 		valid_species = owner.generate_valid_species(check_whitelist, whitelist, blacklist)
-	if(!valid_hairstyles.len || !valid_facial_hairstyles.len)
+	if(!LAZY_LENGTH(valid_hairstyles))
 		valid_hairstyles = owner.generate_valid_hairstyles()
-	if(!valid_facial_hairstyles.len)
+	if(!LAZY_LENGTH(valid_facial_hairstyles))
 		valid_facial_hairstyles = owner.generate_valid_facial_hairstyles()

--- a/code/unit_tests/culture.dm
+++ b/code/unit_tests/culture.dm
@@ -69,7 +69,7 @@
 				if(!islist(species.available_cultural_info[token]))
 					fails++
 					log_bad("Available cultural info for [species_name] tag '[token]' is invalid type, must be a list.")
-				else if(!LAZYLEN(species.available_cultural_info[token]))
+				else if(!LAZY_LENGTH(species.available_cultural_info[token]))
 					fails++
 					log_bad("Available cultural info for [species_name] tag '[token]' is empty, must have at least one entry.")
 				else


### PR DESCRIPTION
## About The Pull Request

A refactor that adds underscores to lazy-access macros and it also includes few fixes to some places that use it. And also removes the superflous custom sprites for AI-cores which are no longer in use. It also fixes a bug in the appearance changer which was thought to be because of lazy access, which turns out to be because Bay used `Cut()` on pass-by-reference lists - instead of nulling them.

## Why It's Good For The Game

Makes the code more pleasant to look at, and could boost the development, thus improving the game even better in the future.

## Changelog
```changelog
fix: Fixed an pass-by-reference issue that deleted all hairs and facial hairs from species lists when using the appearance changer
refactor: Added underscores to lazy-access macro names
```
