### PR TITLE
Remove Unathi regeneration ability

### DIFF
--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -77,19 +77,3 @@
 					if(W.wound_damage() == 0 && prob(50))
 						E.wounds -= W
 	return 1
-
-/obj/aura/regenerating/human/unathi
-	brute_mult = 2
-	organ_mult = 5
-	regen_message = "<span class='warning'>You feel a soothing sensation as your ORGAN mends...</span>"
-	grow_chance = 2
-	grow_threshold = 150
-	ignore_tag = BP_HEAD
-
-/obj/aura/regenerating/human/unathi/external_regeneration_effect(var/obj/item/organ/external/O, var/mob/living/carbon/human/H)
-	to_chat(H, "<span class='danger'>With a shower of fresh blood, a new [O.name] forms.</span>")
-	H.visible_message("<span class='danger'>With a shower of fresh blood, a length of biomass shoots from [H]'s [O.amputation_point], forming a new [O.name]!</span>")
-	H.nutrition -= 50
-	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in H.vessel.reagent_list
-	blood_splatter(H,B,1)
-	O.set_dna(H.dna)

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -69,10 +69,6 @@
 		)
 	breathing_sound = 'sound/voice/lizard.ogg'
 
-	base_auras = list(
-		/obj/aura/regenerating/human/unathi
-		)
-
 	inherent_verbs = list()
 
 	prone_overlay_offset = list(-4, -4)


### PR DESCRIPTION
## About The Pull Request

Unathi's regeneration ability is incredibly broken and overpowered, as it has garned much attention and salt over at UristMcstation. Now that they are removing it (PR: https://github.com/UristMcStation/UristMcStation/pull/1015). I am going to do the same here too. Good bye, you won't be missed.

## Why It's Good For The Game

Balans - also makes it actually possible to perform surgey on Unathi.

## Changelog
```changelog
del: Removed Unathi's regeneration ability
```
