### PR TITLE
Separate Auto-CL action into `generate` and `compile`

### DIFF
--- a/.changelog/.all_changelog.yml
+++ b/.changelog/.all_changelog.yml
@@ -212,3 +212,7 @@
   - refactor: Added underscores to lazy-access macro names
   - rscdel: Removed Unathi's regeneration ability
   - rscdel: Removed the "Make pAI" verb, as there are simpler ways to do it
+  - rscdel: Removed kick mine
+  - tweak: Lowercased names of all mines so far
+  - tweak: Radiation mines now respect protection values against radiation
+  - tweak: All varieties of land mines can now be picked up, armed own, or disarmed.

--- a/.github/workflows/auto_cl_compile.yml
+++ b/.github/workflows/auto_cl_compile.yml
@@ -1,4 +1,4 @@
-name: Changelog Automaker
+name: Changelog Automaker (Compile)
 
 on:
   schedule:

--- a/.github/workflows/auto_cl_compile.yml
+++ b/.github/workflows/auto_cl_compile.yml
@@ -1,8 +1,9 @@
 name: Changelog Automaker
 
 on:
-  push:
-    branches: [master]
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 env:
   GIT_EMAIL: "action@github.com"
@@ -27,8 +28,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ruamel.yaml PyGithub pyyaml bs4
-      - name: Generate CL
-        run: python $CL_AUTOMAKER_DIR/generate_cl.py
       - name: Compile CL
         run: python $CL_AUTOMAKER_DIR/compile_cl.py html/changelog.html .changelog
       - name: Commit
@@ -36,7 +35,7 @@ jobs:
           git config --local user.email $GIT_EMAIL
           git config --local user.name "$GIT_NAME"
           git pull origin master
-          git commit -m "Automatic changelog compile [ci skip]" -a || true
+          git commit -m "Auto-CL compile [ci skip]" -a || true
       - name: Push
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/auto_cl_generate.yml
+++ b/.github/workflows/auto_cl_generate.yml
@@ -1,0 +1,41 @@
+name: Changelog Automaker
+
+on:
+  push:
+    branches: [master]
+
+env:
+  GIT_EMAIL: "action@github.com"
+  GIT_NAME: "Changelog Automaker"
+  CL_AUTOMAKER_DIR: "./tools/ChangelogAutomaker"
+
+jobs:
+  MakeCL:
+    runs-on: ubuntu-latest
+    # discriminator to exclude forks
+    if: github.repository == 'Haven-13/Haven-Urist'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 15
+      - name: Python setup
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install depends
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruamel.yaml PyGithub pyyaml bs4
+      - name: Generate CL
+        run: python $CL_AUTOMAKER_DIR/generate_cl.py
+      - name: Commit
+        run: |
+          git config --local user.email $GIT_EMAIL
+          git config --local user.name "$GIT_NAME"
+          git pull origin master
+          git commit -m "Auto-CL generate [ci skip]" -a || true
+      - name: Push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_cl_generate.yml
+++ b/.github/workflows/auto_cl_generate.yml
@@ -1,4 +1,4 @@
-name: Changelog Automaker
+name: Changelog Automaker (Generate PR CL)
 
 on:
   push:


### PR DESCRIPTION
## About The Pull Request

So, the changelog action I wrote was not idiot-proof, sadly. So I have to take the teachings from the other codebases, and split the changelog automaker to two separate actions. One for generating and other for compiling the CLs.

The compile compiles once a day with the given settings in this PR. Generate triggers every time a PR has been merged with `master`. The usual.

## Why It's Good For The Game

Makes it less likely to cause an error and lose changes to the changelog

## Changelog
```changelog
config: Changelog Automaker has been split into two separate actions to lessen the effect of merge conflicts on the changelog.
```
