### PR TITLE
Fix ZAS' shuttle unit-test

### DIFF
--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -141,6 +141,7 @@
 		testing("Moving [A]")
 		translation += get_turf_translation(get_turf(current_location), get_turf(destination), A.contents)
 	shuttle_moved(destination, translation)
+	testing("[src] has arrived to [destination]")
 	return TRUE
 
 

--- a/code/modules/shuttles/shuttle_ferry.dm
+++ b/code/modules/shuttles/shuttle_ferry.dm
@@ -39,8 +39,8 @@
 /datum/shuttle/autodock/ferry/shuttle_moved()
 	..()
 
-	if (next_location == waypoint_station) location = 0
-	if (next_location == waypoint_offsite) location = 1
+	if (current_location == waypoint_station) location = 0
+	if (current_location == waypoint_offsite) location = 1
 
 /datum/shuttle/autodock/ferry/process_arrived()
 	..()

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -112,6 +112,7 @@
 	async=1				// We're moving the shuttle using built in procs.
 
 	var/datum/shuttle/autodock/ferry/supply/shuttle = null
+	var/initial_location = null  // Account unconventional locations
 
 	var/testtime = 0	//Used as a timer.
 
@@ -132,6 +133,8 @@
 	SSsupply.movetime = 0 // Speed up the shuttle movement.
 	shuttle.warmup_time = 0 // Skip the warmup
 
+	initial_location = shuttle.location // Save this for the check in check_result
+
 	shuttle.short_jump(shuttle.get_location_waypoint(!shuttle.location))
 
 	return 1
@@ -145,7 +148,8 @@
 		skip("This map is using the new cargo system, supply shuttle must be manually verified.")
 		return 1
 
-	if(shuttle.moving_status == SHUTTLE_IDLE && shuttle.at_station())
+	// Has the shuttle actually moved? Or is in it process of moving?
+	if(shuttle.moving_status == SHUTTLE_IDLE && shuttle.location == initial_location)
 		fail("Shuttle Did not Move")
 		return 1
 

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -129,8 +129,10 @@
 		return 1
 
 	// Initiate the Move.
-	SSsupply.movetime = 5 // Speed up the shuttle movement.
-	shuttle.short_jump(shuttle.get_location_waypoint(!shuttle.location)) //TODO
+	SSsupply.movetime = 0 // Speed up the shuttle movement.
+	shuttle.warmup_time = 0 // Skip the warmup
+
+	shuttle.short_jump(shuttle.get_location_waypoint(!shuttle.location))
 
 	return 1
 
@@ -143,12 +145,9 @@
 		skip("This map is using the new cargo system, supply shuttle must be manually verified.")
 		return 1
 
-	if(shuttle.moving_status == SHUTTLE_IDLE && !shuttle.at_station())
+	if(shuttle.moving_status == SHUTTLE_IDLE && shuttle.at_station())
 		fail("Shuttle Did not Move")
 		return 1
-
-	if(!shuttle.at_station())
-		return 0
 
 	if(!testtime)
 		testtime = world.time+40                // Wait another 2 ticks then proceed.


### PR DESCRIPTION
## About The Pull Request

Turns out. The map I made - Tyclo-Pluto, or just simply "AFCUV Pluto" - was not using the supply shuttle the baycode unit-test is expecting them to work. The unit-test expects the shuttle to start at off-site (away from station/ship), but here the shuttle starts on-station (docked to the station/ship). This causes the test to throw false negatives. But the deal is... the unit-test had been throwing false positives as well due to the code checking for `next_location` instead of `current_location` for some reason.

This was happening until I made the #65 PR. And honestly, I've no fucking idea how or what happened to cause the whole facade to tear down and reveal the unit-test to be a very false reassurance.

And I honestly have no idea if this does make the unit-test stop giving false negatives or positives. But this does seem to fix this problem described in particular. 

~~Fuck off Bay and Nebula.~~ begone coder tribalism.

## Why It's Good For The Game

Makes the CI feel more reassuring and stop throwing false negatives. Support maps where the shuttle starts at either the station or remote location.

## Changelog
```changelog
fix: Fix a bug related to the ferry-type shuttles not giving the right values on wherever its current location was.
```
