### PR TITLE
Update `check_regex.py` suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ Session.vim
 # auto-generated tag files
 tags
 dump.txt
+
+# tool-generated files
+check_regex_output.txt

--- a/code/modules/urist/machinery/party.dm
+++ b/code/modules/urist/machinery/party.dm
@@ -71,24 +71,18 @@
 			main_area.forced_ambience = null
 
 /obj/machinery/party/turntable/proc/playmusic()
-//	if(src.playing == 0)
-
 	var/sound/S = sound(track)
 	S.repeat = 1
 	S.channel = 10
 	S.falloff = 2
 	S.wait = 1
 	S.environment = 0
-	//for(var/mob/M in world)
-	//	if(M.loc.loc == src.loc.loc && M.music == 0)
-	//		to_world("Found the song...")
-	//		M << S
-	//		M.music = 1
+
 	var/area/A = src.loc.loc
 
 	for(var/obj/machinery/party/lasermachine/L in A)
 		L.turnon()
-//	playing = 1
+
 	var/area/main_area = get_area(src)
 	main_area.forced_ambience = list(track)
 	for(var/mob/living/M in mobs_in_area(main_area))

--- a/tools/ci/check_regex.py
+++ b/tools/ci/check_regex.py
@@ -73,7 +73,7 @@ cases = [
     exactly(207, "to_world() uses", r'to_world\('),
     exactly(71, "to_world_log() uses", r'to_world_log\('),
 
-    exactly(14, "<< uses", r'(?<!\d)(?<!\d\s)(?<!<)<<(?!=|\s\d|\d|<|\/)'),
+    exactly(14, "non-bitwise << uses", r'(?<!\d)(?<!\d\s)(?<!<)<<(?!=|\s\d|\d|<|\/)'),
     exactly(0, "incorrect indentations", r'^(?:  +)(?!\*)'),
     exactly(0, "superflous whitespace", r'[ \t]+$'),
     exactly(8, "mixed indentation", r'^( +\t+|\t+ +)'),

--- a/tools/ci/check_regex.py
+++ b/tools/ci/check_regex.py
@@ -70,10 +70,10 @@ cases = [
 
     exactly(0, "world<< uses", r'world[ \t]*<<'),
     exactly(0, "world.log<< uses", r'world.log[ \t]*<<'),
-    exactly(208, "to_world() uses", r'to_world\('),
+    exactly(207, "to_world() uses", r'to_world\('),
     exactly(71, "to_world_log() uses", r'to_world_log\('),
 
-    exactly(113, "<< uses", r'(?<!<)<<(?!<)'),
+    exactly(14, "<< uses", r'(?<!\d)(?<!\d\s)(?<!<)<<(?!=|\s\d|\d|<|\/)'),
     exactly(0, "incorrect indentations", r'^(?:  +)(?!\*)'),
     exactly(0, "superflous whitespace", r'[ \t]+$'),
     exactly(8, "mixed indentation", r'^( +\t+|\t+ +)'),


### PR DESCRIPTION
## About The Pull Request

I noticed an issue with `<< uses` would detect and add bitwise shifts to the matchings, when it was intended to find `user << file` and similar non-numerical/bitwise uses.

## Why It's Good For The Game

Makes the CI less misleading and more useful to find suspect non-bitwise uses of the bitwise shifting operation.

## Changelog
```changelog
```
