### PR TITLE
Refactor `obj/screen` to `atom/movable/screen`

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -369,7 +369,7 @@
 	return candidates
 
 /proc/ScreenText(obj/O, maptext="", screen_loc="CENTER-7,CENTER-7", maptext_height=480, maptext_width=480)
-	if(!isobj(O))	O = new /obj/screen/text()
+	if(!isobj(O))	O = new /atom/movable/screen/text()
 	O.maptext = maptext
 	O.maptext_height = maptext_height
 	O.maptext_width = maptext_width

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -339,7 +339,7 @@
 	if(direction != dir)
 		facedir(direction)
 
-/obj/screen/click_catcher
+/atom/movable/screen/click_catcher
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "click_catcher"
 	plane = CLICKCATCHER_PLANE
@@ -350,11 +350,11 @@
 	. = list()
 	for(var/i = 0, i<15, i++)
 		for(var/j = 0, j<15, j++)
-			var/obj/screen/click_catcher/CC = new()
+			var/atom/movable/screen/click_catcher/CC = new()
 			CC.screen_loc = "NORTH-[i],EAST-[j]"
 			. += CC
 
-/obj/screen/click_catcher/Click(location, control, params)
+/atom/movable/screen/click_catcher/Click(location, control, params)
 	var/list/modifiers = params2list(params)
 	if(modifiers["middle"] && istype(usr, /mob/living/carbon))
 		var/mob/living/carbon/C = usr

--- a/code/_onclick/hud/ability_screen_objects.dm
+++ b/code/_onclick/hud/ability_screen_objects.dm
@@ -1,9 +1,9 @@
-/obj/screen/movable/ability_master
+/atom/movable/screen/movable/ability_master
 	name = "Abilities"
 	icon = 'icons/mob/screen_spells.dmi'
 	icon_state = "grey_spell_ready"
-	var/list/obj/screen/ability/ability_objects = list()
-	var/list/obj/screen/ability/spell_objects = list()
+	var/list/atom/movable/screen/ability/ability_objects = list()
+	var/list/atom/movable/screen/ability/spell_objects = list()
 	var/showing = 0 // If we're 'open' or not.
 
 	var/open_state = "master_open"		// What the button looks like when it's 'open', showing the other buttons.
@@ -13,7 +13,7 @@
 
 	var/mob/my_mob = null // The mob that possesses this hud object.
 
-/obj/screen/movable/ability_master/New(newloc,owner)
+/atom/movable/screen/movable/ability_master/New(newloc,owner)
 	if(owner)
 		my_mob = owner
 		update_abilities(0, owner)
@@ -21,7 +21,7 @@
 		CRASH("ERROR: ability_master's New() was not given an owner argument.  This is a bug.")
 	..()
 
-/obj/screen/movable/ability_master/Destroy()
+/atom/movable/screen/movable/ability_master/Destroy()
 	. = ..()
 	//Get rid of the ability objects.
 	remove_all_abilities()
@@ -33,21 +33,21 @@
 		if(my_mob.client && my_mob.client.screen)
 			my_mob.client.screen -= src
 		my_mob = null
-/obj/screen/movable/ability_master/MouseDrop()
+/atom/movable/screen/movable/ability_master/MouseDrop()
 	if(showing)
 		return
 
 	return ..()
 
-/obj/screen/movable/ability_master/Click()
+/atom/movable/screen/movable/ability_master/Click()
 	if(!ability_objects.len) // If we're empty for some reason.
 		return
 
 	toggle_open()
 
-/obj/screen/movable/ability_master/proc/toggle_open(var/forced_state = 0)
+/atom/movable/screen/movable/ability_master/proc/toggle_open(var/forced_state = 0)
 	if(showing && (forced_state != 2)) // We are closing the ability master, hide the abilities.
-		for(var/obj/screen/ability/O in ability_objects)
+		for(var/atom/movable/screen/ability/O in ability_objects)
 			if(my_mob && my_mob.client)
 				my_mob.client.screen -= O
 //			O.handle_icon_updates = 0
@@ -62,7 +62,7 @@
 		overlays.Add(open_state)
 	update_icon()
 
-/obj/screen/movable/ability_master/proc/open_ability_master()
+/atom/movable/screen/movable/ability_master/proc/open_ability_master()
 	var/list/screen_loc_xy = splittext(screen_loc,",")
 
 	//Create list of X offsets
@@ -76,7 +76,7 @@
 	var/y_pix = screen_loc_Y[2]
 
 	for(var/i = 1; i <= ability_objects.len; i++)
-		var/obj/screen/ability/A = ability_objects[i]
+		var/atom/movable/screen/ability/A = ability_objects[i]
 		var/xpos = x_position + (x_position < 8 ? 1 : -1)*(i%7)
 		var/ypos = y_position + (y_position < 8 ? round(i/7) : -round(i/7))
 		A.screen_loc = "[encode_screen_X(xpos, my_mob)]:[x_pix],[encode_screen_Y(ypos, my_mob)]:[y_pix]"
@@ -84,26 +84,26 @@
 			my_mob.client.screen += A
 //			A.handle_icon_updates = 1
 
-/obj/screen/movable/ability_master/proc/update_abilities(forced = 0, mob/user)
+/atom/movable/screen/movable/ability_master/proc/update_abilities(forced = 0, mob/user)
 	update_icon()
 	if(user && user.client)
 		if(!(src in user.client.screen))
 			user.client.screen += src
 	var/i = 1
-	for(var/obj/screen/ability/ability in ability_objects)
+	for(var/atom/movable/screen/ability/ability in ability_objects)
 		ability.update_icon(forced)
 		ability.maptext = "[i]" // Slot number
 		i++
 
-/obj/screen/movable/ability_master/update_icon()
+/atom/movable/screen/movable/ability_master/update_icon()
 	if(ability_objects.len)
 		set_invisibility(0)
 	else
 		set_invisibility(101)
 
-/obj/screen/movable/ability_master/proc/add_ability(var/name_given)
+/atom/movable/screen/movable/ability_master/proc/add_ability(var/name_given)
 	if(!name) return
-	var/obj/screen/ability/new_button = new /obj/screen/ability
+	var/atom/movable/screen/ability/new_button = new /atom/movable/screen/ability
 	new_button.ability_master = src
 	new_button.SetName(name_given)
 	new_button.ability_icon_state = name_given
@@ -112,7 +112,7 @@
 	if(my_mob.client)
 		toggle_open(2) //forces the icons to refresh on screen
 
-/obj/screen/movable/ability_master/proc/remove_ability(var/obj/screen/ability/ability)
+/atom/movable/screen/movable/ability_master/proc/remove_ability(var/atom/movable/screen/ability/ability)
 	if(!ability)
 		return
 	ability_objects.Remove(ability)
@@ -125,24 +125,24 @@
 //	else
 //		qdel(src)
 
-/obj/screen/movable/ability_master/proc/remove_all_abilities()
-	for(var/obj/screen/ability/A in ability_objects)
+/atom/movable/screen/movable/ability_master/proc/remove_all_abilities()
+	for(var/atom/movable/screen/ability/A in ability_objects)
 		remove_ability(A)
 
-/obj/screen/movable/ability_master/proc/get_ability_by_name(name_to_search)
-	for(var/obj/screen/ability/A in ability_objects)
+/atom/movable/screen/movable/ability_master/proc/get_ability_by_name(name_to_search)
+	for(var/atom/movable/screen/ability/A in ability_objects)
 		if(A.name == name_to_search)
 			return A
 	return null
 
-/obj/screen/movable/ability_master/proc/get_ability_by_proc_ref(proc_ref)
-	for(var/obj/screen/ability/verb_based/V in ability_objects)
+/atom/movable/screen/movable/ability_master/proc/get_ability_by_proc_ref(proc_ref)
+	for(var/atom/movable/screen/ability/verb_based/V in ability_objects)
 		if(V.verb_to_call == proc_ref)
 			return V
 	return null
 
-/obj/screen/movable/ability_master/proc/get_ability_by_instance(var/obj/instance/)
-	for(var/obj/screen/ability/obj_based/O in ability_objects)
+/atom/movable/screen/movable/ability_master/proc/get_ability_by_instance(var/obj/instance/)
+	for(var/atom/movable/screen/ability/obj_based/O in ability_objects)
 		if(O.object == instance)
 			return O
 	return null
@@ -155,20 +155,20 @@
 
 /mob/Initialize()
 	. = ..()
-	ability_master = new /obj/screen/movable/ability_master(null,src)
+	ability_master = new /atom/movable/screen/movable/ability_master(null,src)
 
 ///////////ACTUAL ABILITIES////////////
 //This is what you click to do things//
 ///////////////////////////////////////
-/obj/screen/ability
+/atom/movable/screen/ability
 	icon = 'icons/mob/screen_spells.dmi'
 	icon_state = "grey_spell_base"
 	maptext_x = 3
 	var/background_base_state = "grey"
 	var/ability_icon_state = null
-	var/obj/screen/movable/ability_master/ability_master
+	var/atom/movable/screen/movable/ability_master/ability_master
 
-/obj/screen/ability/Destroy()
+/atom/movable/screen/ability/Destroy()
 	if(ability_master)
 		ability_master.ability_objects -= src
 		if(ability_master.my_mob && ability_master.my_mob.client)
@@ -179,25 +179,25 @@
 	ability_master = null
 	return ..()
 
-/obj/screen/ability/update_icon()
+/atom/movable/screen/ability/update_icon()
 	overlays.Cut()
 	icon_state = "[background_base_state]_spell_base"
 
 	overlays += ability_icon_state
 
-/obj/screen/ability/Click()
+/atom/movable/screen/ability/Click()
 	if(!usr)
 		return
 
 	activate()
 
 // Makes the ability be triggered.  The subclasses of this are responsible for carrying it out in whatever way it needs to.
-/obj/screen/ability/proc/activate()
+/atom/movable/screen/ability/proc/activate()
 	to_world("[src] had activate() called.")
 	return
 
 // This checks if the ability can be used.
-/obj/screen/ability/proc/can_activate()
+/atom/movable/screen/ability/proc/can_activate()
 	return 1
 
 /client/verb/activate_ability(var/slot as num)
@@ -212,30 +212,30 @@
 		return // No abilities.
 	if(slot > mob.ability_master.ability_objects.len || slot <= 0)
 		return // Out of bounds.
-	var/obj/screen/ability/A = mob.ability_master.ability_objects[slot]
+	var/atom/movable/screen/ability/A = mob.ability_master.ability_objects[slot]
 	A.activate()
 
 //////////Verb Abilities//////////
 //Buttons to trigger verbs/procs//
 //////////////////////////////////
 
-/obj/screen/ability/verb_based
+/atom/movable/screen/ability/verb_based
 	var/verb_to_call = null
 	var/object_used = null
 	var/arguments_to_use = list()
 
-/obj/screen/ability/verb_based/activate()
+/atom/movable/screen/ability/verb_based/activate()
 	if(object_used && verb_to_call)
 		call(object_used,verb_to_call)(arguments_to_use)
 
-/obj/screen/movable/ability_master/proc/add_verb_ability(var/object_given, var/verb_given, var/name_given, var/ability_icon_given, var/arguments)
+/atom/movable/screen/movable/ability_master/proc/add_verb_ability(var/object_given, var/verb_given, var/name_given, var/ability_icon_given, var/arguments)
 	if(!object_given)
 		message_admins("ERROR: add_verb_ability() was not given an object in its arguments.")
 	if(!verb_given)
 		message_admins("ERROR: add_verb_ability() was not given a verb/proc in its arguments.")
 	if(get_ability_by_proc_ref(verb_given))
 		return // Duplicate
-	var/obj/screen/ability/verb_based/A = new /obj/screen/ability/verb_based()
+	var/atom/movable/screen/ability/verb_based/A = new /atom/movable/screen/ability/verb_based()
 	A.ability_master = src
 	A.object_used = object_given
 	A.verb_to_call = verb_given
@@ -248,18 +248,18 @@
 		toggle_open(2) //forces the icons to refresh on screen
 
 //Changeling Abilities
-/obj/screen/ability/verb_based/changeling
+/atom/movable/screen/ability/verb_based/changeling
 	icon_state = "ling_spell_base"
 	background_base_state = "ling"
 
-/obj/screen/movable/ability_master/proc/add_ling_ability(var/object_given, var/verb_given, var/name_given, var/ability_icon_given, var/arguments)
+/atom/movable/screen/movable/ability_master/proc/add_ling_ability(var/object_given, var/verb_given, var/name_given, var/ability_icon_given, var/arguments)
 	if(!object_given)
 		message_admins("ERROR: add_ling_ability() was not given an object in its arguments.")
 	if(!verb_given)
 		message_admins("ERROR: add_ling_ability() was not given a verb/proc in its arguments.")
 	if(get_ability_by_proc_ref(verb_given))
 		return // Duplicate
-	var/obj/screen/ability/verb_based/changeling/A = new /obj/screen/ability/verb_based/changeling()
+	var/atom/movable/screen/ability/verb_based/changeling/A = new /atom/movable/screen/ability/verb_based/changeling()
 	A.ability_master = src
 	A.object_used = object_given
 	A.verb_to_call = verb_given
@@ -276,9 +276,9 @@
 //Buttons to trigger objects//
 //////////////////////////////
 
-/obj/screen/ability/obj_based
+/atom/movable/screen/ability/obj_based
 	var/obj/object = null
 
-/obj/screen/ability/obj_based/activate()
+/atom/movable/screen/ability/obj_based/activate()
 	if(object)
 		object.Click()

--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -19,7 +19,7 @@
 	var/check_flags = 0
 	var/processing = 0
 	var/active = 0
-	var/obj/screen/movable/action_button/button = null
+	var/atom/movable/screen/movable/action_button/button = null
 	var/button_icon = 'icons/obj/action_buttons/actions.dmi'
 	var/button_icon_state = "default"
 	var/background_icon_state = "bg_default"
@@ -116,11 +116,11 @@
 /datum/action/proc/UpdateName()
 	return name
 
-/obj/screen/movable/action_button
+/atom/movable/screen/movable/action_button
 	var/datum/action/owner
 	screen_loc = "WEST,NORTH"
 
-/obj/screen/movable/action_button/Click(location,control,params)
+/atom/movable/screen/movable/action_button/Click(location,control,params)
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])
 		moved = 0
@@ -130,7 +130,7 @@
 	owner.Trigger()
 	return 1
 
-/obj/screen/movable/action_button/proc/UpdateIcon()
+/atom/movable/screen/movable/action_button/proc/UpdateIcon()
 	if(!owner)
 		return
 	icon = owner.button_icon
@@ -153,13 +153,13 @@
 		color = rgb(255,255,255,255)
 
 //Hide/Show Action Buttons ... Button
-/obj/screen/movable/action_button/hide_toggle
+/atom/movable/screen/movable/action_button/hide_toggle
 	name = "Hide Buttons"
 	icon = 'icons/obj/action_buttons/actions.dmi'
 	icon_state = "bg_default"
 	var/hidden = 0
 
-/obj/screen/movable/action_button/hide_toggle/Click()
+/atom/movable/screen/movable/action_button/hide_toggle/Click()
 	usr.hud_used.action_buttons_hidden = !usr.hud_used.action_buttons_hidden
 
 	hidden = usr.hud_used.action_buttons_hidden
@@ -171,7 +171,7 @@
 	usr.update_action_buttons()
 
 
-/obj/screen/movable/action_button/hide_toggle/proc/InitialiseIcon(var/mob/living/user)
+/atom/movable/screen/movable/action_button/hide_toggle/proc/InitialiseIcon(var/mob/living/user)
 	if(isalien(user))
 		icon_state = "bg_alien"
 	else
@@ -179,7 +179,7 @@
 	UpdateIcon()
 	return
 
-/obj/screen/movable/action_button/hide_toggle/UpdateIcon()
+/atom/movable/screen/movable/action_button/hide_toggle/UpdateIcon()
 	overlays.Cut()
 	var/image/img = image(icon,src,hidden?"show":"hide")
 	overlays += img
@@ -202,7 +202,7 @@
 	var/coord_row_offset = AB_NORTH_OFFSET
 	return "WEST[coord_col]:[coord_col_offset],NORTH[coord_row]:[coord_row_offset]"
 
-/datum/hud/proc/SetButtonCoords(var/obj/screen/button,var/number)
+/datum/hud/proc/SetButtonCoords(var/atom/movable/screen/button,var/number)
 	var/row = round((number-1)/AB_MAX_COLUMNS)
 	var/col = ((number - 1)%(AB_MAX_COLUMNS)) + 1
 	var/x_offset = 32*(col-1) + AB_WEST_OFFSET + 2*col

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -6,9 +6,9 @@
 	src.adding = list()
 	src.other = list()
 
-	var/obj/screen/using
+	var/atom/movable/screen/using
 
-	using = new /obj/screen()
+	using = new /atom/movable/screen()
 	using.SetName("mov_intent")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_alien.dmi'
@@ -17,13 +17,13 @@
 	src.adding += using
 	move_intent = using
 
-	mymob.healths = new /obj/screen()
+	mymob.healths = new /atom/movable/screen()
 	mymob.healths.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.healths.icon_state = "health0"
 	mymob.healths.SetName("health")
 	mymob.healths.screen_loc = ui_alien_health
 
-	mymob.fire = new /obj/screen()
+	mymob.fire = new /atom/movable/screen()
 	mymob.fire.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.fire.icon_state = "fire0"
 	mymob.fire.SetName("fire")

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -6,7 +6,7 @@
 	condition ? overlay_fullscreen(screen_name, screen_type, arg) : clear_fullscreen(screen_name)
 
 /mob/proc/overlay_fullscreen(category, type, severity)
-	var/obj/screen/fullscreen/screen = screens[category]
+	var/atom/movable/screen/fullscreen/screen = screens[category]
 
 	if(screen)
 		if(screen.type != type)
@@ -27,7 +27,7 @@
 	return screen
 
 /mob/proc/clear_fullscreen(category, animated = 10)
-	var/obj/screen/fullscreen/screen = screens[category]
+	var/atom/movable/screen/fullscreen/screen = screens[category]
 	if(!screen)
 		return
 
@@ -59,7 +59,7 @@
 		for(var/category in screens)
 			client.screen |= screens[category]
 
-/obj/screen/fullscreen
+/atom/movable/screen/fullscreen
 	icon = 'icons/mob/screen_full.dmi'
 	icon_state = "default"
 	screen_loc = "CENTER-7,CENTER-7"
@@ -68,62 +68,62 @@
 	var/severity = 0
 	var/allstate = 0 //shows if it should show up for dead people too
 
-/obj/screen/fullscreen/Destroy()
+/atom/movable/screen/fullscreen/Destroy()
 	severity = 0
 	return ..()
 
-/obj/screen/fullscreen/brute
+/atom/movable/screen/fullscreen/brute
 	icon_state = "brutedamageoverlay"
 	layer = DAMAGE_LAYER
 
-/obj/screen/fullscreen/oxy
+/atom/movable/screen/fullscreen/oxy
 	icon_state = "oxydamageoverlay"
 	layer = DAMAGE_LAYER
 
-/obj/screen/fullscreen/crit
+/atom/movable/screen/fullscreen/crit
 	icon_state = "passage"
 	layer = CRIT_LAYER
 
-/obj/screen/fullscreen/blind
+/atom/movable/screen/fullscreen/blind
 	icon_state = "blackimageoverlay"
 	layer = BLIND_LAYER
 
-/obj/screen/fullscreen/blackout
+/atom/movable/screen/fullscreen/blackout
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "black"
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	layer = BLIND_LAYER
 
-/obj/screen/fullscreen/impaired
+/atom/movable/screen/fullscreen/impaired
 	icon_state = "impairedoverlay"
 	layer = IMPAIRED_LAYER
 
-/obj/screen/fullscreen/blurry
+/atom/movable/screen/fullscreen/blurry
 	icon = 'icons/mob/screen1.dmi'
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	icon_state = "blurry"
 
-/obj/screen/fullscreen/flash
+/atom/movable/screen/fullscreen/flash
 	icon = 'icons/mob/screen1.dmi'
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	icon_state = "flash"
 
-/obj/screen/fullscreen/flash/noise
+/atom/movable/screen/fullscreen/flash/noise
 	icon_state = "noise"
 
-/obj/screen/fullscreen/high
+/atom/movable/screen/fullscreen/high
 	icon = 'icons/mob/screen1.dmi'
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	icon_state = "druggy"
 
-/obj/screen/fullscreen/noise
+/atom/movable/screen/fullscreen/noise
 	icon = 'icons/effects/static.dmi'
 	icon_state = "1 light"
 	screen_loc = ui_entire_screen
 	layer = FULLSCREEN_LAYER
 	alpha = 127
 
-/obj/screen/fullscreen/fadeout
+/atom/movable/screen/fullscreen/fadeout
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "black"
 	screen_loc = ui_entire_screen
@@ -131,21 +131,21 @@
 	alpha = 0
 	allstate = 1
 
-/obj/screen/fullscreen/fadeout/Initialize()
+/atom/movable/screen/fullscreen/fadeout/Initialize()
 	. = ..()
 	animate(src, alpha = 255, time = 10)
 
-/obj/screen/fullscreen/scanline
+/atom/movable/screen/fullscreen/scanline
 	icon = 'icons/effects/static.dmi'
 	icon_state = "scanlines"
 	screen_loc = ui_entire_screen
 	alpha = 50
 	layer = FULLSCREEN_LAYER
 
-/obj/screen/fullscreen/fishbed
+/atom/movable/screen/fullscreen/fishbed
 	icon_state = "fishbed"
 	allstate = 1
 
-/obj/screen/fullscreen/pain
+/atom/movable/screen/fullscreen/pain
 	icon_state = "brutedamageoverlay6"
 	alpha = 0

--- a/code/_onclick/hud/global_hud.dm
+++ b/code/_onclick/hud/global_hud.dm
@@ -6,13 +6,13 @@
 GLOBAL_DATUM_INIT(global_hud, /datum/global_hud, new())
 
 /datum/global_hud
-	var/obj/screen/nvg
-	var/obj/screen/thermal
-	var/obj/screen/meson
-	var/obj/screen/science
+	var/atom/movable/screen/nvg
+	var/atom/movable/screen/thermal
+	var/atom/movable/screen/meson
+	var/atom/movable/screen/science
 
 /datum/global_hud/proc/setup_overlay(var/icon_state)
-	var/obj/screen/screen = new /obj/screen()
+	var/atom/movable/screen/screen = new /atom/movable/screen()
 	screen.screen_loc = "1,1"
 	screen.icon = 'icons/obj/hud_full.dmi'
 	screen.icon_state = icon_state

--- a/code/_onclick/hud/gun_mode.dm
+++ b/code/_onclick/hud/gun_mode.dm
@@ -1,20 +1,20 @@
-/obj/screen/gun
+/atom/movable/screen/gun
 	name = "gun"
 	icon = 'icons/mob/screen1.dmi'
 	master = null
 	dir = 2
 
-/obj/screen/gun/Click(location, control, params)
+/atom/movable/screen/gun/Click(location, control, params)
 	if(!usr)
 		return
 	return 1
 
-/obj/screen/gun/move
+/atom/movable/screen/gun/move
 	name = "Allow Movement"
 	icon_state = "no_walk0"
 	screen_loc = ui_gun2
 
-/obj/screen/gun/move/Click(location, control, params)
+/atom/movable/screen/gun/move/Click(location, control, params)
 	if(..())
 		var/mob/living/user = usr
 		if(istype(user))
@@ -23,12 +23,12 @@
 		return 1
 	return 0
 
-/obj/screen/gun/item
+/atom/movable/screen/gun/item
 	name = "Allow Item Use"
 	icon_state = "no_item0"
 	screen_loc = ui_gun1
 
-/obj/screen/gun/item/Click(location, control, params)
+/atom/movable/screen/gun/item/Click(location, control, params)
 	if(..())
 		var/mob/living/user = usr
 		if(istype(user))
@@ -37,12 +37,12 @@
 		return 1
 	return 0
 
-/obj/screen/gun/mode
+/atom/movable/screen/gun/mode
 	name = "Toggle Gun Mode"
 	icon_state = "gun0"
 	screen_loc = ui_gun_select
 
-/obj/screen/gun/mode/Click(location, control, params)
+/atom/movable/screen/gun/mode/Click(location, control, params)
 	if(..())
 		var/mob/living/user = usr
 		if(istype(user))
@@ -51,12 +51,12 @@
 		return 1
 	return 0
 
-/obj/screen/gun/radio
+/atom/movable/screen/gun/radio
 	name = "Disallow Radio Use"
 	icon_state = "no_radio1"
 	screen_loc = ui_gun4
 
-/obj/screen/gun/radio/Click(location, control, params)
+/atom/movable/screen/gun/radio/Click(location, control, params)
 	if(..())
 		var/mob/living/user = usr
 		if(istype(user))

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -29,19 +29,19 @@
 	var/show_intent_icons = 0
 	var/hotkey_ui_hidden = 0	//This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
 
-	var/obj/screen/lingchemdisplay
-	var/obj/screen/r_hand_hud_object
-	var/obj/screen/l_hand_hud_object
-	var/obj/screen/action_intent
-	var/obj/screen/move_intent
+	var/atom/movable/screen/lingchemdisplay
+	var/atom/movable/screen/r_hand_hud_object
+	var/atom/movable/screen/l_hand_hud_object
+	var/atom/movable/screen/action_intent
+	var/atom/movable/screen/move_intent
 
-	var/obj/screen/plane_master/emissive/hud_emissive_catcher
+	var/atom/movable/screen/plane_master/emissive/hud_emissive_catcher
 
 	var/list/adding
 	var/list/other
-	var/list/obj/screen/hotkeybuttons
+	var/list/atom/movable/screen/hotkeybuttons
 
-	var/obj/screen/movable/action_button/hide_toggle/hide_actions_toggle
+	var/atom/movable/screen/movable/action_button/hide_toggle/hide_actions_toggle
 	var/action_buttons_hidden = 0
 
 	var/previous_z_depth
@@ -77,7 +77,7 @@
 	mymob = owner
 	world_map_view = new/atom/movable/map_view()
 
-	hud_emissive_catcher = new/obj/screen/plane_master/emissive()
+	hud_emissive_catcher = new/atom/movable/screen/plane_master/emissive()
 	hud_emissive_catcher.set_plane(
 		HUD_PLANE + (EMISSIVE_PLANE - OBJ_PLANE)
 	)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -17,14 +17,14 @@
 	src.hotkeybuttons = list() //These can be disabled for hotkey usersx
 
 	var/list/hud_elements = list()
-	var/obj/screen/using
-	var/obj/screen/inventory/inv_box
+	var/atom/movable/screen/using
+	var/atom/movable/screen/inventory/inv_box
 
 	// Draw the various inventory equipment slots.
 	var/has_hidden_gear
 	for(var/gear_slot in hud_data.gear)
 
-		inv_box = new /obj/screen/inventory()
+		inv_box = new /atom/movable/screen/inventory()
 		inv_box.icon = ui_style
 		inv_box.color = ui_color
 		inv_box.alpha = ui_alpha
@@ -45,7 +45,7 @@
 			src.adding += inv_box
 
 	if(has_hidden_gear)
-		using = new /obj/screen()
+		using = new /atom/movable/screen()
 		using.SetName("toggle")
 		using.icon = ui_style
 		using.icon_state = "other"
@@ -57,14 +57,14 @@
 	// Draw the attack intent dialogue.
 	if(hud_data.has_a_intent)
 
-		using = new /obj/screen/intent()
+		using = new /atom/movable/screen/intent()
 		src.adding += using
 		action_intent = using
 
 		hud_elements |= using
 
 	if(hud_data.has_m_intent)
-		using = new /obj/screen()
+		using = new /atom/movable/screen()
 		using.SetName("mov_intent")
 		using.icon = ui_style
 		using.icon_state = mymob.move_intent.hud_icon_state
@@ -75,7 +75,7 @@
 		move_intent = using
 
 	if(hud_data.has_drop)
-		using = new /obj/screen()
+		using = new /atom/movable/screen()
 		using.SetName("drop")
 		using.icon = ui_style
 		using.icon_state = "act_drop"
@@ -86,7 +86,7 @@
 
 	if(hud_data.has_hands)
 
-		using = new /obj/screen()
+		using = new /atom/movable/screen()
 		using.SetName("equip")
 		using.icon = ui_style
 		using.icon_state = "act_equip"
@@ -95,7 +95,7 @@
 		using.alpha = ui_alpha
 		src.adding += using
 
-		inv_box = new /obj/screen/inventory()
+		inv_box = new /atom/movable/screen/inventory()
 		inv_box.SetName("r_hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "r_hand_inactive"
@@ -109,7 +109,7 @@
 		src.r_hand_hud_object = inv_box
 		src.adding += inv_box
 
-		inv_box = new /obj/screen/inventory()
+		inv_box = new /atom/movable/screen/inventory()
 		inv_box.SetName("l_hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "l_hand_inactive"
@@ -122,7 +122,7 @@
 		src.l_hand_hud_object = inv_box
 		src.adding += inv_box
 
-		using = new /obj/screen/inventory()
+		using = new /atom/movable/screen/inventory()
 		using.SetName("hand")
 		using.icon = ui_style
 		using.icon_state = "hand1"
@@ -131,7 +131,7 @@
 		using.alpha = ui_alpha
 		src.adding += using
 
-		using = new /obj/screen/inventory()
+		using = new /atom/movable/screen/inventory()
 		using.SetName("hand")
 		using.icon = ui_style
 		using.icon_state = "hand2"
@@ -141,7 +141,7 @@
 		src.adding += using
 
 	if(hud_data.has_resist)
-		using = new /obj/screen()
+		using = new /atom/movable/screen()
 		using.SetName("resist")
 		using.icon = ui_style
 		using.icon_state = "act_resist"
@@ -151,7 +151,7 @@
 		src.hotkeybuttons += using
 
 	if(hud_data.has_throw)
-		mymob.throw_icon = new /obj/screen()
+		mymob.throw_icon = new /atom/movable/screen()
 		mymob.throw_icon.icon = ui_style
 		mymob.throw_icon.icon_state = "act_throw_off"
 		mymob.throw_icon.SetName("throw")
@@ -161,7 +161,7 @@
 		src.hotkeybuttons += mymob.throw_icon
 		hud_elements |= mymob.throw_icon
 
-		mymob.pullin = new /obj/screen()
+		mymob.pullin = new /atom/movable/screen()
 		mymob.pullin.icon = ui_style
 		mymob.pullin.icon_state = "pull0"
 		mymob.pullin.SetName("pull")
@@ -170,7 +170,7 @@
 		hud_elements |= mymob.pullin
 
 	if(hud_data.has_internals)
-		mymob.internals = new /obj/screen()
+		mymob.internals = new /atom/movable/screen()
 		mymob.internals.icon = ui_style
 		mymob.internals.icon_state = "internal0"
 		mymob.internals.SetName("internal")
@@ -178,28 +178,28 @@
 		hud_elements |= mymob.internals
 
 	if(hud_data.has_warnings)
-		mymob.oxygen = new /obj/screen()
+		mymob.oxygen = new /atom/movable/screen()
 		mymob.oxygen.icon = ui_style
 		mymob.oxygen.icon_state = "oxy0"
 		mymob.oxygen.SetName("oxygen")
 		mymob.oxygen.screen_loc = ui_oxygen
 		hud_elements |= mymob.oxygen
 
-		mymob.toxin = new /obj/screen()
+		mymob.toxin = new /atom/movable/screen()
 		mymob.toxin.icon = ui_style
 		mymob.toxin.icon_state = "tox0"
 		mymob.toxin.SetName("toxin")
 		mymob.toxin.screen_loc = ui_toxin
 		hud_elements |= mymob.toxin
 
-		mymob.fire = new /obj/screen()
+		mymob.fire = new /atom/movable/screen()
 		mymob.fire.icon = ui_style
 		mymob.fire.icon_state = "fire0"
 		mymob.fire.SetName("fire")
 		mymob.fire.screen_loc = ui_fire
 		hud_elements |= mymob.fire
 
-		mymob.healths = new /obj/screen()
+		mymob.healths = new /atom/movable/screen()
 		mymob.healths.icon = ui_style
 		mymob.healths.icon_state = "health0"
 		mymob.healths.SetName("health")
@@ -207,7 +207,7 @@
 		hud_elements |= mymob.healths
 
 	if(hud_data.has_pressure)
-		mymob.pressure = new /obj/screen()
+		mymob.pressure = new /atom/movable/screen()
 		mymob.pressure.icon = ui_style
 		mymob.pressure.icon_state = "pressure0"
 		mymob.pressure.SetName("pressure")
@@ -215,7 +215,7 @@
 		hud_elements |= mymob.pressure
 
 	if(hud_data.has_bodytemp)
-		mymob.bodytemp = new /obj/screen()
+		mymob.bodytemp = new /atom/movable/screen()
 		mymob.bodytemp.icon = ui_style
 		mymob.bodytemp.icon_state = "temp1"
 		mymob.bodytemp.SetName("body temperature")
@@ -223,7 +223,7 @@
 		hud_elements |= mymob.bodytemp
 
 	if(target.isSynthetic())
-		target.cells = new /obj/screen()
+		target.cells = new /atom/movable/screen()
 		target.cells.icon = 'icons/mob/screen1_robot.dmi'
 		target.cells.icon_state = "charge-empty"
 		target.cells.SetName("cell")
@@ -231,7 +231,7 @@
 		hud_elements |= target.cells
 
 	else if(hud_data.has_nutrition)
-		mymob.nutrition_icon = new /obj/screen()
+		mymob.nutrition_icon = new /atom/movable/screen()
 		mymob.nutrition_icon.icon = ui_style
 		mymob.nutrition_icon.icon_state = "nutrition0"
 		mymob.nutrition_icon.SetName("nutrition")
@@ -239,10 +239,10 @@
 		hud_elements |= mymob.nutrition_icon
 
 
-	mymob.pain = new /obj/screen/fullscreen/pain( null )
+	mymob.pain = new /atom/movable/screen/fullscreen/pain( null )
 	hud_elements |= mymob.pain
 
-	mymob.zone_sel = new /obj/screen/zone_sel( null )
+	mymob.zone_sel = new /atom/movable/screen/zone_sel( null )
 	mymob.zone_sel.icon = ui_style
 	mymob.zone_sel.color = ui_color
 	mymob.zone_sel.alpha = ui_alpha
@@ -251,23 +251,23 @@
 	hud_elements |= mymob.zone_sel
 
 	//Handle the gun settings buttons
-	mymob.gun_setting_icon = new /obj/screen/gun/mode(null)
+	mymob.gun_setting_icon = new /atom/movable/screen/gun/mode(null)
 	mymob.gun_setting_icon.icon = ui_style
 	mymob.gun_setting_icon.color = ui_color
 	mymob.gun_setting_icon.alpha = ui_alpha
 	hud_elements |= mymob.gun_setting_icon
 
-	mymob.item_use_icon = new /obj/screen/gun/item(null)
+	mymob.item_use_icon = new /atom/movable/screen/gun/item(null)
 	mymob.item_use_icon.icon = ui_style
 	mymob.item_use_icon.color = ui_color
 	mymob.item_use_icon.alpha = ui_alpha
 
-	mymob.gun_move_icon = new /obj/screen/gun/move(null)
+	mymob.gun_move_icon = new /atom/movable/screen/gun/move(null)
 	mymob.gun_move_icon.icon = ui_style
 	mymob.gun_move_icon.color = ui_color
 	mymob.gun_move_icon.alpha = ui_alpha
 
-	mymob.radio_use_icon = new /obj/screen/gun/radio(null)
+	mymob.radio_use_icon = new /atom/movable/screen/gun/radio(null)
 	mymob.radio_use_icon.icon = ui_style
 	mymob.radio_use_icon.color = ui_color
 	mymob.radio_use_icon.alpha = ui_alpha

--- a/code/_onclick/hud/map_view.dm
+++ b/code/_onclick/hud/map_view.dm
@@ -1,7 +1,7 @@
 /atom/movable/map_view
 	var/assigned_map
-	var/list/obj/screen/plane_master/plane_master_cache = list()
-	var/list/obj/screen/openspace_overlay/openspace_overlay_cache = list()
+	var/list/atom/movable/screen/plane_master/plane_master_cache = list()
+	var/list/atom/movable/screen/openspace_overlay/openspace_overlay_cache = list()
 
 	var/list/active_planes = list()
 	var/list/active_overlays = list()
@@ -23,10 +23,10 @@
 	active_overlays.Cut()
 
 	for(var/idx in 1 to z_depth)
-		for(var/mytype in subtypesof(/obj/screen/plane_master))
+		for(var/mytype in subtypesof(/atom/movable/screen/plane_master))
 			var/key = "[idx]-[mytype]"
 			if(!plane_master_cache.Find(key))
-				var/obj/screen/plane_master/instance = new mytype()
+				var/atom/movable/screen/plane_master/instance = new mytype()
 				instance.update_screen_plane(idx)
 				instance.screen_loc = "CENTER"
 				if(assigned_map)
@@ -39,7 +39,7 @@
 			for (var/pidx in multiz_rendering_planes())
 				var/key = "[idx]-[pidx]"
 				if(!openspace_overlay_cache.Find(key))
-					var/obj/screen/openspace_overlay/oover = new
+					var/atom/movable/screen/openspace_overlay/oover = new
 					oover.plane = calculate_plane(idx, pidx)
 					oover.alpha = min(255,z_delta*60 + 30)
 					oover.screen_loc = "CENTER"
@@ -53,12 +53,12 @@
 		return
 
 	for(var/key in active_planes)
-		var/obj/screen/plane_master/PM = active_planes[key]
+		var/atom/movable/screen/plane_master/PM = active_planes[key]
 		mymob.client.screen += PM
 		PM.backdrop(mymob)
 
 	for(var/key in active_overlays)
-		var/obj/screen/openspace_overlay/OO = active_overlays[key]
+		var/atom/movable/screen/openspace_overlay/OO = active_overlays[key]
 		mymob.client.screen += OO
 
 /atom/movable/map_view/proc/clear_all(var/mob/mymob)
@@ -66,11 +66,11 @@
 		return
 
 	for(var/key in active_planes)
-		var/obj/screen/plane_master/PM = active_planes[key]
+		var/atom/movable/screen/plane_master/PM = active_planes[key]
 		mymob.client.screen -= PM
 
 	for(var/key in active_overlays)
-		var/obj/screen/openspace_overlay/OO = active_overlays[key]
+		var/atom/movable/screen/openspace_overlay/OO = active_overlays[key]
 		mymob.client.screen -= OO
 
 /atom/movable/map_view/proc/get_active_planes()

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -8,18 +8,18 @@
 //Movable Screen Object
 //Not tied to the grid, places it's center where the cursor is
 
-/obj/screen/movable
+/atom/movable/screen/movable
 	var/snap2grid = FALSE
 	var/moved = FALSE
 
 //Snap Screen Object
 //Tied to the grid, snaps to the nearest turf
 
-/obj/screen/movable/snap
+/atom/movable/screen/movable/snap
 	snap2grid = TRUE
 
 
-/obj/screen/movable/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
+/atom/movable/screen/movable/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
 	var/list/PM = params2list(params)
 
 	//No screen-loc information? abort.
@@ -44,7 +44,7 @@
 		var/pix_Y = text2num(screen_loc_Y[2]) - 16
 		screen_loc = "[screen_loc_X[1]]:[pix_X],[screen_loc_Y[1]]:[pix_Y]"
 
-/obj/screen/movable/proc/encode_screen_X(var/X, var/mob/viewer)
+/atom/movable/screen/movable/proc/encode_screen_X(var/X, var/mob/viewer)
 	var/view = viewer.client ? viewer.client.view : world.view
 	if(X > view+1)
 		. = "EAST-[view*2 + 1-X]"
@@ -53,7 +53,7 @@
 	else
 		. = "CENTER"
 
-/obj/screen/movable/proc/decode_screen_X(var/X, var/mob/viewer)
+/atom/movable/screen/movable/proc/decode_screen_X(var/X, var/mob/viewer)
 	var/view = viewer.client ? viewer.client.view : world.view
 	//Find EAST/WEST implementations
 	if(findtext(X,"EAST-"))
@@ -69,7 +69,7 @@
 	else if(findtext(X,"CENTER"))
 		. = view+1
 
-/obj/screen/movable/proc/encode_screen_Y(var/Y, var/mob/viewer)
+/atom/movable/screen/movable/proc/encode_screen_Y(var/Y, var/mob/viewer)
 	var/view = viewer.client ? viewer.client.view : world.view
 	if(Y > view+1)
 		. = "NORTH-[view*2 + 1-Y]"
@@ -78,7 +78,7 @@
 	else
 		. = "CENTER"
 
-/obj/screen/movable/proc/decode_screen_Y(var/Y, var/mob/viewer)
+/atom/movable/screen/movable/proc/decode_screen_Y(var/Y, var/mob/viewer)
 	var/view = viewer.client ? viewer.client.view : world.view
 	if(findtext(Y,"NORTH-"))
 		var/num = text2num(copytext(Y,7)) //Trim NORTH-
@@ -98,7 +98,7 @@
 	set category = "Debug"
 	set name = "Spawn Movable UI Object"
 
-	var/obj/screen/movable/M = new()
+	var/atom/movable/screen/movable/M = new()
 	M.SetName("Movable UI Object")
 	M.icon_state = "block"
 	M.maptext = "Movable"
@@ -117,7 +117,7 @@
 	set category = "Debug"
 	set name = "Spawn Snap UI Object"
 
-	var/obj/screen/movable/snap/S = new()
+	var/atom/movable/screen/movable/snap/S = new()
 	S.SetName("Snap UI Object")
 	S.icon_state = "block"
 	S.maptext = "Snap"

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -4,9 +4,9 @@
 /datum/hud/slime/FinalizeInstantiation(ui_style = 'icons/mob/screen1_Midnight.dmi')
 	src.adding = list()
 
-	var/obj/screen/using
+	var/atom/movable/screen/using
 
-	using = new /obj/screen/intent()
+	using = new /atom/movable/screen/intent()
 	src.adding += using
 	action_intent = using
 

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -2,7 +2,7 @@
 //	PLANE MASTERS
 //
 
-/obj/screen/plane_master
+/atom/movable/screen/plane_master
 	screen_loc = "CENTER,CENTER"
 	icon_state = "blank"
 	globalscreen = 1
@@ -11,22 +11,22 @@
 	var/show_alpha = 255
 	var/hide_alpha = 0
 
-/obj/screen/plane_master/proc/update_screen_plane(z_level)
+/atom/movable/screen/plane_master/proc/update_screen_plane(z_level)
 	if(initial(src.render_target))
 		src.render_target = "[initial(src.render_target)]-[z_level]z"
 	else
 		src.render_target = "[src.plane]-[z_level]z"
 	src.plane = calculate_plane(z_level, src.plane)
 
-/obj/screen/plane_master/proc/Show(override)
+/atom/movable/screen/plane_master/proc/Show(override)
 	alpha = override || show_alpha
 
-/obj/screen/plane_master/proc/Hide(override)
+/atom/movable/screen/plane_master/proc/Hide(override)
 	alpha = override || hide_alpha
 
 //Why do plane masters need a backdrop sometimes? Read https://secure.byond.com/forum/?post=2141928
 //Trust me, you need one. Period. If you don't think you do, you're doing something extremely wrong.
-/obj/screen/plane_master/proc/backdrop(mob/mymob)
+/atom/movable/screen/plane_master/proc/backdrop(mob/mymob)
 
 /*
  *  I hate myself, I hate Baycode, I hate Byond
@@ -41,76 +41,76 @@
 #define EMISSIVE_RENDER_TARGET "*emissive_render_target"
 #define VISIBLE_GAME_WORLD_RENDER "*visible_game_world_render"
 
-/obj/screen/plane_master/space_master
+/atom/movable/screen/plane_master/space_master
 	plane = SPACE_PLANE
 
-/obj/screen/plane_master/space_master/update_screen_plane(z_level)
+/atom/movable/screen/plane_master/space_master/update_screen_plane(z_level)
 	return
 
-/obj/screen/plane_master/openspace_master
+/atom/movable/screen/plane_master/openspace_master
 	plane = OPENSPACE_PLANE
 
-/obj/screen/plane_master/below_turf_master
+/atom/movable/screen/plane_master/below_turf_master
 	plane = BELOW_TURF_PLANE
 
-/obj/screen/plane_master/plating_plane_master
+/atom/movable/screen/plane_master/plating_plane_master
 	plane = PLATING_PLANE
 
-/obj/screen/plane_master/above_plating_master
+/atom/movable/screen/plane_master/above_plating_master
 	plane = ABOVE_PLATING_PLANE
 
-/obj/screen/plane_master/turf_master
+/atom/movable/screen/plane_master/turf_master
 	plane = TURF_PLANE
 
-/obj/screen/plane_master/above_turf_master
+/atom/movable/screen/plane_master/above_turf_master
 	plane = ABOVE_TURF_PLANE
 
-/obj/screen/plane_master/under_obj_master
+/atom/movable/screen/plane_master/under_obj_master
 	plane = UNDER_OBJ_PLANE
 
-/obj/screen/plane_master/hiding_mob_master
+/atom/movable/screen/plane_master/hiding_mob_master
 	plane = HIDING_MOB_PLANE
 
-/obj/screen/plane_master/obj_plane_master
+/atom/movable/screen/plane_master/obj_plane_master
 	plane = OBJ_PLANE
 
-/obj/screen/plane_master/lying_mob_master
+/atom/movable/screen/plane_master/lying_mob_master
 	plane = LYING_MOB_PLANE
 
-/obj/screen/plane_master/lying_human_master
+/atom/movable/screen/plane_master/lying_human_master
 	plane = LYING_HUMAN_PLANE
 
-/obj/screen/plane_master/above_obj_master
+/atom/movable/screen/plane_master/above_obj_master
 	plane = ABOVE_OBJ_PLANE
 
-/obj/screen/plane_master/human_plane_master
+/atom/movable/screen/plane_master/human_plane_master
 	plane = HUMAN_PLANE
 
-/obj/screen/plane_master/mob_plane_master
+/atom/movable/screen/plane_master/mob_plane_master
 	plane = MOB_PLANE
 
-/obj/screen/plane_master/above_human_master
+/atom/movable/screen/plane_master/above_human_master
 	plane = ABOVE_HUMAN_PLANE
 
-/obj/screen/plane_master/blob_plane_master
+/atom/movable/screen/plane_master/blob_plane_master
 	plane = BLOB_PLANE
 
-/obj/screen/plane_master/effects_below_lighting_master
+/atom/movable/screen/plane_master/effects_below_lighting_master
 	plane = EFFECTS_BELOW_LIGHTING_PLANE
 
-/obj/screen/plane_master/observer_master
+/atom/movable/screen/plane_master/observer_master
 	plane = OBSERVER_PLANE
 
-/obj/screen/plane_master/visible_game_world_plane_master
+/atom/movable/screen/plane_master/visible_game_world_plane_master
 	plane = VISIBLE_GAME_WORLD_PLANE
 	render_target = VISIBLE_GAME_WORLD_RENDER
 	mouse_opacity = 0    // nothing on this plane is mouse-visible
 
-/obj/screen/plane_master/visible_game_world_plane_master/update_screen_plane(z_level)
+/atom/movable/screen/plane_master/visible_game_world_plane_master/update_screen_plane(z_level)
 	..()
 	update_composite(z_level)
 
-/obj/screen/plane_master/visible_game_world_plane_master/proc/update_composite(z)
+/atom/movable/screen/plane_master/visible_game_world_plane_master/proc/update_composite(z)
 	for (var/plane in BELOW_TURF_PLANE to OBSERVER_PLANE)
 		filters += filter(
 			type="layer",
@@ -118,18 +118,18 @@
 			blend_mode=BLEND_ADD
 		)
 
-/obj/screen/plane_master/lighting_plane
+/atom/movable/screen/plane_master/lighting_plane
 	name = "lighting plane master"
 	plane = LIGHTING_PLANE
 
 	blend_mode = BLEND_MULTIPLY
 	mouse_opacity = 0    // nothing on this plane is mouse-visible
 
-/obj/screen/plane_master/lighting_plane/update_screen_plane(z_level)
+/atom/movable/screen/plane_master/lighting_plane/update_screen_plane(z_level)
 	..()
 	update_masks(z_level)
 
-/obj/screen/plane_master/lighting_plane/proc/update_masks(z)
+/atom/movable/screen/plane_master/lighting_plane/proc/update_masks(z)
 	filters += filter(
 		type="alpha",
 		render_source="[VISIBLE_GAME_WORLD_RENDER]-[z]z"
@@ -140,20 +140,20 @@
 		flags=MASK_INVERSE
 	)
 
-/obj/screen/plane_master/emissive
+/atom/movable/screen/plane_master/emissive
 	name = "emissive plane master"
 	plane = EMISSIVE_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	render_target = EMISSIVE_RENDER_TARGET
 
-/obj/screen/plane_master/emissive/Initialize()
+/atom/movable/screen/plane_master/emissive/Initialize()
 	. = ..()
 	filters += filter(
 		type="color",
 		color=GLOB.em_mask_matrix
 	)
 
-/obj/screen/plane_master/obscurity_master
+/atom/movable/screen/plane_master/obscurity_master
 	plane = OBSCURITY_PLANE
 
 #undef VISIBLE_GAME_WORLD_RENDER

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -1,4 +1,4 @@
-var/obj/screen/robot_inventory
+var/atom/movable/screen/robot_inventory
 
 /mob/living/silicon/robot
 	hud_type = /datum/hud/robot
@@ -8,12 +8,12 @@ var/obj/screen/robot_inventory
 	src.adding = list()
 	src.other = list()
 
-	var/obj/screen/using
+	var/atom/movable/screen/using
 
 	var/mob/living/silicon/robot/myrobot = mymob
 
 //Radio
-	using = new /obj/screen()
+	using = new /atom/movable/screen()
 	using.SetName("radio")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_robot.dmi'
@@ -23,7 +23,7 @@ var/obj/screen/robot_inventory
 
 //Module select
 
-	using = new /obj/screen()
+	using = new /atom/movable/screen()
 	using.SetName("module1")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_robot.dmi'
@@ -32,7 +32,7 @@ var/obj/screen/robot_inventory
 	src.adding += using
 	myrobot.inv1 = using
 
-	using = new /obj/screen()
+	using = new /atom/movable/screen()
 	using.SetName("module2")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_robot.dmi'
@@ -41,7 +41,7 @@ var/obj/screen/robot_inventory
 	src.adding += using
 	myrobot.inv2 = using
 
-	using = new /obj/screen()
+	using = new /atom/movable/screen()
 	using.SetName("module3")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_robot.dmi'
@@ -53,7 +53,7 @@ var/obj/screen/robot_inventory
 //End of module select
 
 //Intent
-	using = new /obj/screen()
+	using = new /atom/movable/screen()
 	using.SetName("act_intent")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_robot.dmi'
@@ -63,28 +63,28 @@ var/obj/screen/robot_inventory
 	action_intent = using
 
 //Cell
-	myrobot.cells = new /obj/screen()
+	myrobot.cells = new /atom/movable/screen()
 	myrobot.cells.icon = 'icons/mob/screen1_robot.dmi'
 	myrobot.cells.icon_state = "charge-empty"
 	myrobot.cells.SetName("cell")
 	myrobot.cells.screen_loc = ui_toxin
 
 //Health
-	mymob.healths = new /obj/screen()
+	mymob.healths = new /atom/movable/screen()
 	mymob.healths.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.healths.icon_state = "health0"
 	mymob.healths.SetName("health")
 	mymob.healths.screen_loc = ui_borg_health
 
 //Installed Module
-	mymob.hands = new /obj/screen()
+	mymob.hands = new /atom/movable/screen()
 	mymob.hands.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.hands.icon_state = "nomod"
 	mymob.hands.SetName("module")
 	mymob.hands.screen_loc = ui_borg_module
 
 //Module Panel
-	using = new /obj/screen()
+	using = new /atom/movable/screen()
 	using.SetName("panel")
 	using.icon = 'icons/mob/screen1_robot.dmi'
 	using.icon_state = "panel"
@@ -92,54 +92,54 @@ var/obj/screen/robot_inventory
 	src.adding += using
 
 //Store
-	mymob.throw_icon = new /obj/screen()
+	mymob.throw_icon = new /atom/movable/screen()
 	mymob.throw_icon.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.throw_icon.icon_state = "store"
 	mymob.throw_icon.SetName("store")
 	mymob.throw_icon.screen_loc = ui_borg_store
 
 //Inventory
-	robot_inventory = new /obj/screen()
+	robot_inventory = new /atom/movable/screen()
 	robot_inventory.SetName("inventory")
 	robot_inventory.icon = 'icons/mob/screen1_robot.dmi'
 	robot_inventory.icon_state = "inventory"
 	robot_inventory.screen_loc = ui_borg_inventory
 
 //Temp
-	mymob.bodytemp = new /obj/screen()
+	mymob.bodytemp = new /atom/movable/screen()
 	mymob.bodytemp.icon_state = "temp0"
 	mymob.bodytemp.SetName("body temperature")
 	mymob.bodytemp.screen_loc = ui_temp
 
 
-	mymob.oxygen = new /obj/screen()
+	mymob.oxygen = new /atom/movable/screen()
 	mymob.oxygen.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.oxygen.icon_state = "oxy0"
 	mymob.oxygen.SetName("oxygen")
 	mymob.oxygen.screen_loc = ui_oxygen
 
-	mymob.fire = new /obj/screen()
+	mymob.fire = new /atom/movable/screen()
 	mymob.fire.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.fire.icon_state = "fire0"
 	mymob.fire.SetName("fire")
 	mymob.fire.screen_loc = ui_fire
 
-	mymob.pullin = new /obj/screen()
+	mymob.pullin = new /atom/movable/screen()
 	mymob.pullin.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.SetName("pull")
 	mymob.pullin.screen_loc = ui_borg_pull
 
-	mymob.zone_sel = new /obj/screen/zone_sel()
+	mymob.zone_sel = new /atom/movable/screen/zone_sel()
 	mymob.zone_sel.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.zone_sel.overlays.Cut()
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
 
 	//Handle the gun settings buttons
-	mymob.gun_setting_icon = new /obj/screen/gun/mode(null)
-	mymob.item_use_icon = new /obj/screen/gun/item(null)
-	mymob.gun_move_icon = new /obj/screen/gun/move(null)
-	mymob.radio_use_icon = new /obj/screen/gun/radio(null)
+	mymob.gun_setting_icon = new /atom/movable/screen/gun/mode(null)
+	mymob.item_use_icon = new /atom/movable/screen/gun/item(null)
+	mymob.gun_move_icon = new /atom/movable/screen/gun/move(null)
+	mymob.radio_use_icon = new /atom/movable/screen/gun/radio(null)
 
 	mymob.client.screen = list()
 	mymob.client.screen += list(mymob.throw_icon, mymob.zone_sel, mymob.oxygen, mymob.fire, mymob.hands, mymob.healths, myrobot.cells, mymob.pullin, robot_inventory, mymob.gun_setting_icon)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -12,7 +12,6 @@
 	plane = HUD_PLANE
 	layer = HUD_BASE_LAYER
 	appearance_flags = NO_CLIENT_COLOR
-	unacidable = 1
 	var/obj/master = null	//A reference to the object in the slot. Grabs or items, generally.
 	var/globalscreen = FALSE //Global screens are not qdeled when the holding mob is destroyed.
 	appearance_flags = NO_CLIENT_COLOR

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -6,7 +6,7 @@
 	They are used with the client/screen list and the screen_loc var.
 	For more information, see the byond documentation on the screen_loc and screen vars.
 */
-/obj/screen
+/atom/movable/screen
 	name = ""
 	icon = 'icons/mob/screen1.dmi'
 	plane = HUD_PLANE
@@ -17,17 +17,17 @@
 	var/globalscreen = FALSE //Global screens are not qdeled when the holding mob is destroyed.
 	appearance_flags = NO_CLIENT_COLOR
 
-/obj/screen/update_plane()
+/atom/movable/screen/update_plane()
 	return
 
-/obj/screen/set_plane(new_plane)
+/atom/movable/screen/set_plane(new_plane)
 	plane = new_plane
 
-/obj/screen/Destroy()
+/atom/movable/screen/Destroy()
 	master = null
 	return ..()
 
-/obj/screen/text
+/atom/movable/screen/text
 	icon = null
 	icon_state = null
 	mouse_opacity = 0
@@ -40,21 +40,21 @@
  * It is also implicitly used to allocate a rectangle on the map, which will
  * be used for auto-scaling the map.
  */
-/obj/screen/background
+/atom/movable/screen/background
 	name = "background"
 	icon_state = "blank"
 	layer = MAP_VIEW_LAYER
 	plane = MAP_VIEW_PLANE
 
 
-/obj/screen/inventory
+/atom/movable/screen/inventory
 	var/slot_id	//The indentifier for the slot. It has nothing to do with ID cards.
 
 
-/obj/screen/close
+/atom/movable/screen/close
 	name = "close"
 
-/obj/screen/close/Click()
+/atom/movable/screen/close/Click()
 	if(master)
 		if(istype(master, /obj/item/weapon/storage))
 			var/obj/item/weapon/storage/S = master
@@ -62,14 +62,14 @@
 	return 1
 
 
-/obj/screen/item_action
+/atom/movable/screen/item_action
 	var/obj/item/owner
 
-/obj/screen/item_action/Destroy()
+/atom/movable/screen/item_action/Destroy()
 	..()
 	owner = null
 
-/obj/screen/item_action/Click()
+/atom/movable/screen/item_action/Click()
 	if(!usr || !owner)
 		return 1
 	if(!usr.canClick())
@@ -84,10 +84,10 @@
 	owner.ui_action_click()
 	return 1
 
-/obj/screen/storage
+/atom/movable/screen/storage
 	name = "storage"
 
-/obj/screen/storage/Click()
+/atom/movable/screen/storage/Click()
 	if(!usr.canClick())
 		return 1
 	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
@@ -98,13 +98,13 @@
 		usr.ClickOn(master)
 	return 1
 
-/obj/screen/zone_sel
+/atom/movable/screen/zone_sel
 	name = "damage zone"
 	icon_state = "zone_sel"
 	screen_loc = ui_zonesel
 	var/selecting = BP_CHEST
 
-/obj/screen/zone_sel/Click(location, control,params)
+/atom/movable/screen/zone_sel/Click(location, control,params)
 	var/list/PL = params2list(params)
 	var/icon_x = text2num(PL["icon-x"])
 	var/icon_y = text2num(PL["icon-y"])
@@ -165,24 +165,24 @@
 		update_icon()
 	return 1
 
-/obj/screen/zone_sel/proc/set_selected_zone(bodypart)
+/atom/movable/screen/zone_sel/proc/set_selected_zone(bodypart)
 	var/old_selecting = selecting
 	selecting = bodypart
 	if(old_selecting != selecting)
 		update_icon()
 
-/obj/screen/zone_sel/update_icon()
+/atom/movable/screen/zone_sel/update_icon()
 	overlays.Cut()
 	overlays += mutable_appearance('icons/mob/zone_sel.dmi', "[selecting]")
 
-/obj/screen/intent
+/atom/movable/screen/intent
 	name = "intent"
 	icon = 'icons/mob/screen1_White.dmi'
 	icon_state = "intent_help"
 	screen_loc = ui_acti
 	var/intent = I_HELP
 
-/obj/screen/intent/Click(var/location, var/control, var/params)
+/atom/movable/screen/intent/Click(var/location, var/control, var/params)
 	var/list/P = params2list(params)
 	var/icon_x = text2num(P["icon-x"])
 	var/icon_y = text2num(P["icon-y"])
@@ -197,10 +197,10 @@
 	update_icon()
 	usr.a_intent = intent
 
-/obj/screen/intent/update_icon()
+/atom/movable/screen/intent/update_icon()
 	icon_state = "intent_[intent]"
 
-/obj/screen/Click(location, control, params)
+/atom/movable/screen/Click(location, control, params)
 	if(!usr)	return 1
 	switch(name)
 		if("toggle")
@@ -394,7 +394,7 @@
 			return 0
 	return 1
 
-/obj/screen/inventory/Click()
+/atom/movable/screen/inventory/Click()
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
 	// We don't even know if it's a middle click
 	if(!usr.canClick())

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -156,7 +156,7 @@
 	if (evacuation_controller && evacuation_controller.cancel_evacuation())
 		log_and_message_admins("[key_name(user)] has cancelled the bluespace jump.")
 
-/obj/screen/fullscreen/bluespace_overlay
+/atom/movable/screen/fullscreen/bluespace_overlay
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "mfoam"
 	screen_loc = "WEST,SOUTH to EAST,NORTH"

--- a/code/datums/cinematic.dm
+++ b/code/datums/cinematic.dm
@@ -4,7 +4,7 @@ GLOBAL_DATUM_INIT(cinematic, /datum/cinematic, new)
 /datum/cinematic
 	//station_explosion used to be a variable for every mob's hud. Which was a waste!
 	//Now we have a general cinematic centrally held within the gameticker....far more efficient!
-	var/obj/screen/cinematic_screen = null
+	var/atom/movable/screen/cinematic_screen = null
 
 //Plus it provides an easy way to make cinematics for other events. Just use this as a template :)
 /datum/cinematic/proc/station_explosion_cinematic(var/station_missed=0, var/datum/game_mode/override)

--- a/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
+++ b/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
@@ -51,7 +51,7 @@
 	bluespaced += M
 	if(M.client)
 		to_chat(M,"<span class='notice'>You feel oddly light, and somewhat disoriented as everything around you shimmers and warps ever so slightly.</span>")
-		M.overlay_fullscreen("bluespace", /obj/screen/fullscreen/bluespace_overlay)
+		M.overlay_fullscreen("bluespace", /atom/movable/screen/fullscreen/bluespace_overlay)
 	M.confused = 20
 	bluegoasts += new/obj/effect/bluegoast/(get_turf(M),M)
 
@@ -130,7 +130,7 @@
 	daddy.dust()
 	qdel(src)
 
-/obj/screen/fullscreen/bluespace_overlay
+/atom/movable/screen/fullscreen/bluespace_overlay
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "mfoam"
 	screen_loc = "WEST,SOUTH to EAST,NORTH"

--- a/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
+++ b/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
@@ -3,7 +3,7 @@ GLOBAL_VAR(universe_has_ended)
 /datum/universal_state/nuclear_explosion
 	name = "Nuclear Demolition Warhead"
 	var/atom/explosion_source
-	var/obj/screen/cinematic
+	var/atom/movable/screen/cinematic
 
 /datum/universal_state/nuclear_explosion/New(atom/nuke)
 	explosion_source = nuke

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -460,7 +460,7 @@ var/global/list/additional_antag_types = list()
 	return
 
 // Manipulates the end-game cinematic in conjunction with GLOB.cinematic
-/datum/game_mode/proc/nuke_act(obj/screen/cinematic_screen, station_missed = 0)
+/datum/game_mode/proc/nuke_act(atom/movable/screen/cinematic_screen, station_missed = 0)
 	if(!cinematic_icon_states)
 		return
 	if(station_missed < 2)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -55,9 +55,9 @@
 /obj/machinery/camera/apply_visual(mob/living/carbon/human/M)
 	if(!M.client)
 		return
-	M.overlay_fullscreen("fishbed",/obj/screen/fullscreen/fishbed)
-	M.overlay_fullscreen("scanlines",/obj/screen/fullscreen/scanline)
-	M.overlay_fullscreen("whitenoise",/obj/screen/fullscreen/noise)
+	M.overlay_fullscreen("fishbed",/atom/movable/screen/fullscreen/fishbed)
+	M.overlay_fullscreen("scanlines",/atom/movable/screen/fullscreen/scanline)
+	M.overlay_fullscreen("whitenoise",/atom/movable/screen/fullscreen/noise)
 	M.machine_visual = src
 	return 1
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -262,8 +262,8 @@
 		mech_click = world.time
 
 		if(!istype(object, /atom)) return
-		if(istype(object, /obj/screen))
-			var/obj/screen/using = object
+		if(istype(object, /atom/movable/screen))
+			var/atom/movable/screen/using = object
 			if(using.screen_loc == ui_acti || using.screen_loc == ui_iarrowleft || using.screen_loc == ui_iarrowright)//ignore all HUD objects save 'intent' and its arrows
 				return ..()
 			else

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -20,8 +20,8 @@ GLOBAL_LIST(end_titles)
 	LAZY_INIT(credits)
 
 	if(mob)
-		mob.overlay_fullscreen("fishbed",/obj/screen/fullscreen/fishbed)
-		mob.overlay_fullscreen("fadeout",/obj/screen/fullscreen/fadeout)
+		mob.overlay_fullscreen("fishbed",/atom/movable/screen/fullscreen/fishbed)
+		mob.overlay_fullscreen("fadeout",/atom/movable/screen/fullscreen/fadeout)
 
 		if(mob.get_preference_value(/datum/client_preference/play_lobby_music) == GLOB.PREF_YES)
 			sound_to(mob, sound(null, channel = GLOB.lobby_sound_channel))
@@ -35,7 +35,7 @@ GLOBAL_LIST(end_titles)
 	for(var/I in GLOB.end_titles)
 		if(!credits)
 			return
-		var/obj/screen/credit/T = new(null, I, src)
+		var/atom/movable/screen/credit/T = new(null, I, src)
 		_credits += T
 		T.rollem()
 		sleep(CREDIT_SPAWN_SPEED)
@@ -53,7 +53,7 @@ GLOBAL_LIST(end_titles)
 	mob.clear_fullscreen("fadeout")
 	sound_to(mob, sound(null, channel = GLOB.lobby_sound_channel))
 
-/obj/screen/credit
+/atom/movable/screen/credit
 	icon_state = "blank"
 	mouse_opacity = 0
 	alpha = 0
@@ -63,14 +63,14 @@ GLOBAL_LIST(end_titles)
 	var/client/parent
 	var/matrix/target
 
-/obj/screen/credit/Initialize(mapload, credited, client/P)
+/atom/movable/screen/credit/Initialize(mapload, credited, client/P)
 	. = ..()
 	parent = P
 	maptext = credited
 	maptext_height = world.icon_size * 2
 	maptext_width = world.icon_size * 14
 
-/obj/screen/credit/proc/rollem()
+/atom/movable/screen/credit/proc/rollem()
 	var/matrix/M = matrix(transform)
 	M.Translate(0, CREDIT_ANIMATE_HEIGHT)
 	animate(src, transform = M, time = CREDIT_ROLL_SPEED)
@@ -83,7 +83,7 @@ GLOBAL_LIST(end_titles)
 			qdel(src)
 	parent.screen += src
 
-/obj/screen/credit/Destroy()
+/atom/movable/screen/credit/Destroy()
 	var/client/P = parent
 	if(parent)
 		P.screen -= src

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -337,7 +337,7 @@
 
 /obj/item/device/radio/headset/MouseDrop(var/obj/over_object)
 	var/mob/M = usr
-	if((!istype(over_object, /obj/screen)) && (src in M) && CanUseTopic(M))
+	if((!istype(over_object, /atom/movable/screen)) && (src in M) && CanUseTopic(M))
 		return attack_self(M)
 	return
 

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -39,7 +39,7 @@
 			src.open(user)
 			return 0
 
-		if (!( istype(over_object, /obj/screen) ))
+		if (!( istype(over_object, /atom/movable/screen) ))
 			return 1
 
 		//makes sure master_item is equipped before putting it in hand, so that we can't drag it into our hand from miles away.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -40,7 +40,7 @@
 			src.open(usr)
 			return TRUE
 
-		if (!( istype(over_object, /obj/screen) ))
+		if (!( istype(over_object, /atom/movable/screen) ))
 			return ..()
 
 		//makes sure that the storage is equipped, so that we can't drag it into our hand from miles away.

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -1,40 +1,40 @@
 /datum/storage_ui/default
 	var/list/is_seeing = new/list() //List of mobs which are currently seeing the contents of this item's storage
 
-	var/obj/screen/storage/boxes
-	var/obj/screen/storage/storage_start //storage UI
-	var/obj/screen/storage/storage_continue
-	var/obj/screen/storage/storage_end
-	var/obj/screen/storage/stored_start
-	var/obj/screen/storage/stored_continue
-	var/obj/screen/storage/stored_end
+	var/atom/movable/screen/storage/boxes
+	var/atom/movable/screen/storage/storage_start //storage UI
+	var/atom/movable/screen/storage/storage_continue
+	var/atom/movable/screen/storage/storage_end
+	var/atom/movable/screen/storage/stored_start
+	var/atom/movable/screen/storage/stored_continue
+	var/atom/movable/screen/storage/stored_end
 
-	var/list/obj/screen/storage/containers
+	var/list/atom/movable/screen/storage/containers
 
-	var/obj/screen/close/closer
+	var/atom/movable/screen/close/closer
 
 /datum/storage_ui/default/New(var/storage)
 	..()
-	boxes = new /obj/screen/storage(  )
+	boxes = new /atom/movable/screen/storage(  )
 	boxes.SetName("storage")
 	boxes.master = storage
 	boxes.icon_state = "block"
 	boxes.screen_loc = "7,7 to 10,8"
 	boxes.layer = HUD_BASE_LAYER
 
-	storage_start = new /obj/screen/storage(  )
+	storage_start = new /atom/movable/screen/storage(  )
 	storage_start.SetName("storage")
 	storage_start.master = storage
 	storage_start.icon_state = "storage_start"
 	storage_start.screen_loc = "7,7 to 10,8"
 	storage_start.layer = HUD_BASE_LAYER
-	storage_continue = new /obj/screen/storage(  )
+	storage_continue = new /atom/movable/screen/storage(  )
 	storage_continue.SetName("storage")
 	storage_continue.master = storage
 	storage_continue.icon_state = "storage_continue"
 	storage_continue.screen_loc = "7,7 to 10,8"
 	storage_continue.layer = HUD_BASE_LAYER
-	storage_end = new /obj/screen/storage(  )
+	storage_end = new /atom/movable/screen/storage(  )
 	storage_end.SetName("storage")
 	storage_end.master = storage
 	storage_end.icon_state = "storage_end"
@@ -59,7 +59,7 @@
 
 	containers = list()
 
-	closer = new /obj/screen/close(  )
+	closer = new /atom/movable/screen/close(  )
 	closer.master = storage
 	closer.icon_state = "x"
 	closer.layer = HUD_BASE_LAYER
@@ -206,7 +206,7 @@
 	boxes.screen_loc = "4:16,2:16 to [4+cols]:16,[2+rows]:16"
 
 	for(var/obj/O in storage.contents)
-		var/obj/screen/storage/box = new()
+		var/atom/movable/screen/storage/box = new()
 		box.SetName(O.name)
 		box.master = O
 		box.icon_state = "block"
@@ -258,7 +258,7 @@
 		stored_continue.transform = M_continue
 		stored_end.transform = M_end
 
-		var/obj/screen/storage/container = new()
+		var/atom/movable/screen/storage/container = new()
 		container.screen_loc = "4:16,2:16"
 		container.icon_state = "blank"
 		container.layer = HUD_CLICKABLE_LAYER

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -326,7 +326,7 @@
 	qdel(src)
 
 /obj/structure/closet/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
-	if(istype(O, /obj/screen))	//fix for HUD elements making their way into the world	-Pete
+	if(istype(O, /atom/movable/screen))	//fix for HUD elements making their way into the world	-Pete
 		return
 	if(O.loc == user)
 		return

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -44,7 +44,7 @@
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
 	preload_rsc = 0 // This is 0 so we can set it to an URL once the player logs in and have them download the resources from a different server.
-	var/static/obj/screen/click_catcher/void
+	var/static/atom/movable/screen/click_catcher/void
 
 	///Last ping of the client
 	var/lastping = 0

--- a/code/modules/client/ui_style.dm
+++ b/code/modules/client/ui_style.dm
@@ -43,7 +43,7 @@
 
 	var/icon/ic = all_ui_styles[UI_style_new]
 
-	for(var/obj/screen/I in icons)
+	for(var/atom/movable/screen/I in icons)
 		if(I.name in list(I_HELP, I_HURT, I_DISARM, I_GRAB)) continue
 		I.icon = ic
 		I.color = UI_style_color_new

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -11,7 +11,7 @@
 	var/off_state = "degoggles"
 	var/active = TRUE
 	var/activation_sound = 'sound/items/goggles_charge.ogg'
-	var/obj/screen/overlay = null
+	var/atom/movable/screen/overlay = null
 	var/obj/item/clothing/glasses/hud/hud = null	// Hud glasses, if any
 	var/electric = FALSE //if the glasses should be disrupted by EMP
 

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -107,12 +107,12 @@
 
 	if(stat != DEAD)
 		if(blinded)
-			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+			overlay_fullscreen("blind", /atom/movable/screen/fullscreen/blind)
 		else
 			clear_fullscreen("blind")
-			set_fullscreen(disabilities & NEARSIGHTED, "impaired", /obj/screen/fullscreen/impaired, 1)
-			set_fullscreen(eye_blurry, "blurry", /obj/screen/fullscreen/blurry)
-			set_fullscreen(druggy, "high", /obj/screen/fullscreen/high)
+			set_fullscreen(disabilities & NEARSIGHTED, "impaired", /atom/movable/screen/fullscreen/impaired, 1)
+			set_fullscreen(eye_blurry, "blurry", /atom/movable/screen/fullscreen/blurry)
+			set_fullscreen(druggy, "high", /atom/movable/screen/fullscreen/high)
 		if(machine)
 			if(machine.check_eye(src) < 0)
 				reset_view(null)

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -178,12 +178,12 @@
 
 	if(stat != DEAD)
 		if(blinded)
-			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+			overlay_fullscreen("blind", /atom/movable/screen/fullscreen/blind)
 		else
 			clear_fullscreen("blind")
-			set_fullscreen(disabilities & NEARSIGHTED, "impaired", /obj/screen/fullscreen/impaired, 1)
-			set_fullscreen(eye_blurry, "blurry", /obj/screen/fullscreen/blurry)
-			set_fullscreen(druggy, "high", /obj/screen/fullscreen/high)
+			set_fullscreen(disabilities & NEARSIGHTED, "impaired", /atom/movable/screen/fullscreen/impaired, 1)
+			set_fullscreen(eye_blurry, "blurry", /atom/movable/screen/fullscreen/blurry)
+			set_fullscreen(druggy, "high", /atom/movable/screen/fullscreen/high)
 		if (machine)
 			if (!( machine.check_eye(src) ))
 				reset_view(null)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -237,7 +237,7 @@
 /mob/living/carbon/proc/eyecheck()
 	return 0
 
-/mob/living/carbon/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /obj/screen/fullscreen/flash)
+/mob/living/carbon/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /atom/movable/screen/fullscreen/flash)
 	if(eyecheck() < intensity || override_blindness_check)
 		return ..()
 
@@ -275,7 +275,7 @@
 	src.throw_mode_off()
 	if(usr.stat || !target)
 		return
-	if(target.type == /obj/screen) return
+	if(target.type == /atom/movable/screen) return
 
 	var/atom/movable/item = src.get_active_hand()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -540,7 +540,7 @@
 		return FLASH_PROTECTION_MAJOR
 	return total_protection
 
-/mob/living/carbon/human/flash_eyes(var/intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /obj/screen/fullscreen/flash)
+/mob/living/carbon/human/flash_eyes(var/intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /atom/movable/screen/fullscreen/flash)
 	if(internal_organs_by_name[BP_EYES]) // Eyes are fucked, not a 'weak point'.
 		var/obj/item/organ/internal/eyes/I = internal_organs_by_name[BP_EYES]
 		I.additional_flash_effects(intensity)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -657,7 +657,7 @@
 				if(-90 to -80)			severity = 8
 				if(-95 to -90)			severity = 9
 				if(-INFINITY to -95)	severity = 10
-			overlay_fullscreen("crit", /obj/screen/fullscreen/crit, severity)
+			overlay_fullscreen("crit", /atom/movable/screen/fullscreen/crit, severity)
 		else
 			clear_fullscreen("crit")
 			//Oxygen damage overlay
@@ -671,7 +671,7 @@
 					if(35 to 40)		severity = 5
 					if(40 to 45)		severity = 6
 					if(45 to INFINITY)	severity = 7
-				overlay_fullscreen("oxy", /obj/screen/fullscreen/oxy, severity)
+				overlay_fullscreen("oxy", /atom/movable/screen/fullscreen/oxy, severity)
 			else
 				clear_fullscreen("oxy")
 
@@ -687,7 +687,7 @@
 				if(55 to 70)		severity = 4
 				if(70 to 85)		severity = 5
 				if(85 to INFINITY)	severity = 6
-			overlay_fullscreen("brute", /obj/screen/fullscreen/brute, severity)
+			overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)
 		else
 			clear_fullscreen("brute")
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -170,12 +170,12 @@
 		return
 
 	if(eye_blind)
-		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+		overlay_fullscreen("blind", /atom/movable/screen/fullscreen/blind)
 	else
 		clear_fullscreen("blind")
-		set_fullscreen(disabilities & NEARSIGHTED, "impaired", /obj/screen/fullscreen/impaired, 1)
-		set_fullscreen(eye_blurry, "blurry", /obj/screen/fullscreen/blurry)
-		set_fullscreen(druggy, "high", /obj/screen/fullscreen/high)
+		set_fullscreen(disabilities & NEARSIGHTED, "impaired", /atom/movable/screen/fullscreen/impaired, 1)
+		set_fullscreen(eye_blurry, "blurry", /atom/movable/screen/fullscreen/blurry)
+		set_fullscreen(druggy, "high", /atom/movable/screen/fullscreen/high)
 
 	if(machine)
 		var/viewflags = machine.check_eye(src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -659,7 +659,7 @@ default behaviour is:
 	to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"]</span>")
 
 //called when the mob receives a bright flash
-/mob/living/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /obj/screen/fullscreen/flash)
+/mob/living/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /atom/movable/screen/fullscreen/flash)
 	if(override_blindness_check || !(disabilities & BLIND))
 		overlay_fullscreen("flash", type)
 		spawn(25)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -374,11 +374,11 @@
 	for(var/datum/action/A in actions)
 		button_number++
 		if(A.button == null)
-			var/obj/screen/movable/action_button/N = new(hud_used)
+			var/atom/movable/screen/movable/action_button/N = new(hud_used)
 			N.owner = A
 			A.button = N
 
-		var/obj/screen/movable/action_button/B = A.button
+		var/atom/movable/screen/movable/action_button/B = A.button
 
 		B.UpdateIcon()
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -49,6 +49,6 @@
 	var/job = null//Living
 	var/list/obj/aura/auras = null //Basically a catch-all aura/force-field thing.
 
-	var/obj/screen/cells = null
+	var/atom/movable/screen/cells = null
 
 	var/last_resist = 0

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -53,7 +53,7 @@
 /mob/living/silicon/ai/update_living_sight()
 	if(!has_power() || self_shutdown)
 		update_icon()
-		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+		overlay_fullscreen("blind", /atom/movable/screen/fullscreen/blind)
 		set_sight(sight&(~SEE_TURFS)&(~SEE_MOBS)&(~SEE_OBJS))
 		set_see_in_dark(0)
 		set_see_invisible(SEE_INVISIBLE_LIVING)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -236,12 +236,12 @@
 
 	if(stat != DEAD)
 		if(blinded)
-			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+			overlay_fullscreen("blind", /atom/movable/screen/fullscreen/blind)
 		else
 			clear_fullscreen("blind")
-			set_fullscreen(disabilities & NEARSIGHTED, "impaired", /obj/screen/fullscreen/impaired, 1)
-			set_fullscreen(eye_blurry, "blurry", /obj/screen/fullscreen/blurry)
-			set_fullscreen(druggy, "high", /obj/screen/fullscreen/high)
+			set_fullscreen(disabilities & NEARSIGHTED, "impaired", /atom/movable/screen/fullscreen/impaired, 1)
+			set_fullscreen(eye_blurry, "blurry", /atom/movable/screen/fullscreen/blurry)
+			set_fullscreen(druggy, "high", /atom/movable/screen/fullscreen/high)
 
 		if (machine)
 			if (machine.check_eye(src) < 0)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -33,12 +33,12 @@
 
 //Hud stuff
 
-	var/obj/screen/inv1 = null
-	var/obj/screen/inv2 = null
-	var/obj/screen/inv3 = null
+	var/atom/movable/screen/inv1 = null
+	var/atom/movable/screen/inv2 = null
+	var/atom/movable/screen/inv3 = null
 
 	var/shown_robot_modules = 0 //Used to determine whether they have the module menu shown or not
-	var/obj/screen/robot_modules_background
+	var/atom/movable/screen/robot_modules_background
 
 //3 Modules can be activated at any one time.
 	var/obj/item/weapon/robot_module/module = null

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -372,6 +372,6 @@
 	ghostize(0)
 	qdel(src)
 
-/mob/living/silicon/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /obj/screen/fullscreen/flash)
+/mob/living/silicon/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /atom/movable/screen/fullscreen/flash)
 	if(affect_silicon)
 		return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -10,7 +10,7 @@
 	if(client)
 		remove_screen_obj_references()
 		for(var/atom/movable/AM in client.screen)
-			var/obj/screen/screenobj = AM
+			var/atom/movable/screen/screenobj = AM
 			if(!istype(screenobj) || !screenobj.globalscreen)
 				qdel(screenobj)
 		client.screen = list()
@@ -1070,7 +1070,7 @@
 	return (!alpha || !mouse_opacity || viewer.see_invisible < invisibility)
 
 /client/proc/check_has_body_select()
-	return mob && mob.hud_used && istype(mob.zone_sel, /obj/screen/zone_sel)
+	return mob && mob.hud_used && istype(mob.zone_sel, /atom/movable/screen/zone_sel)
 
 /client/verb/body_toggle_head()
 	set name = "body-toggle-head"
@@ -1110,7 +1110,7 @@
 /client/proc/toggle_zone_sel(list/zones)
 	if(!check_has_body_select())
 		return
-	var/obj/screen/zone_sel/selector = mob.zone_sel
+	var/atom/movable/screen/zone_sel/selector = mob.zone_sel
 	selector.set_selected_zone(next_in_list(mob.zone_sel.selecting,zones))
 
 /mob/proc/has_chem_effect(chem, threshold)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -34,28 +34,28 @@
 
 	var/stat = 0 //Whether a mob is alive or dead. TODO: Move this to living - Nodrak
 
-	var/obj/screen/hands = null
-	var/obj/screen/pullin = null
-	var/obj/screen/purged = null
-	var/obj/screen/internals = null
-	var/obj/screen/oxygen = null
-	var/obj/screen/i_select = null
-	var/obj/screen/m_select = null
-	var/obj/screen/toxin = null
-	var/obj/screen/fire = null
-	var/obj/screen/bodytemp = null
-	var/obj/screen/healths = null
-	var/obj/screen/throw_icon = null
-	var/obj/screen/nutrition_icon = null
-	var/obj/screen/pressure = null
-	var/obj/screen/pain = null
-	var/obj/screen/gun/item/item_use_icon = null
-	var/obj/screen/gun/radio/radio_use_icon = null
-	var/obj/screen/gun/move/gun_move_icon = null
-	var/obj/screen/gun/run/gun_run_icon = null
-	var/obj/screen/gun/mode/gun_setting_icon = null
+	var/atom/movable/screen/hands = null
+	var/atom/movable/screen/pullin = null
+	var/atom/movable/screen/purged = null
+	var/atom/movable/screen/internals = null
+	var/atom/movable/screen/oxygen = null
+	var/atom/movable/screen/i_select = null
+	var/atom/movable/screen/m_select = null
+	var/atom/movable/screen/toxin = null
+	var/atom/movable/screen/fire = null
+	var/atom/movable/screen/bodytemp = null
+	var/atom/movable/screen/healths = null
+	var/atom/movable/screen/throw_icon = null
+	var/atom/movable/screen/nutrition_icon = null
+	var/atom/movable/screen/pressure = null
+	var/atom/movable/screen/pain = null
+	var/atom/movable/screen/gun/item/item_use_icon = null
+	var/atom/movable/screen/gun/radio/radio_use_icon = null
+	var/atom/movable/screen/gun/move/gun_move_icon = null
+	var/atom/movable/screen/gun/run/gun_run_icon = null
+	var/atom/movable/screen/gun/mode/gun_setting_icon = null
 
-	var/obj/screen/movable/ability_master/ability_master = null
+	var/atom/movable/screen/movable/ability_master/ability_master = null
 
 	/*A bunch of this stuff really needs to go under their own defines instead of being globally attached to mob.
 	A variable should only be globally attached to turfs/objects/whatever, when it is in fact needed as such.
@@ -63,7 +63,7 @@
 	I'll make some notes on where certain variable defines should probably go.
 	Changing this around would probably require a good look-over the pre-existing code.
 	*/
-	var/obj/screen/zone_sel/zone_sel = null
+	var/atom/movable/screen/zone_sel/zone_sel = null
 
 	var/use_me = 1 //Allows all mobs to use the me verb by default, will have to manually specify they cannot
 	var/damageoverlaytemp = 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -601,7 +601,7 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 	if(client)
 		client.images -= image
 
-/mob/proc/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /obj/screen/fullscreen/flash)
+/mob/proc/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /atom/movable/screen/fullscreen/flash)
 	return
 
 /mob/proc/fully_replace_character_name(var/new_name, var/in_depth = TRUE)

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -291,7 +291,7 @@
 
 /obj/item/modular_computer/MouseDrop(var/atom/over_object)
 	var/mob/M = usr
-	if(!istype(over_object, /obj/screen) && CanMouseDrop(M))
+	if(!istype(over_object, /atom/movable/screen) && CanMouseDrop(M))
 		return attack_self(M)
 
 /obj/item/modular_computer/afterattack(atom/target, mob/user, proximity)

--- a/code/modules/modular_computers/ui_modules/camera_monitor.dm
+++ b/code/modules/modular_computers/ui_modules/camera_monitor.dm
@@ -34,8 +34,8 @@
 	var/list/turf/last_camera_turf = list()
 
 	var/list/atom/movable/map_view/camera_map_views = list()
-	var/list/obj/screen/background/camera_foregrounds = list()
-	var/list/obj/screen/background/camera_skyboxes = list()
+	var/list/atom/movable/screen/background/camera_foregrounds = list()
+	var/list/atom/movable/screen/background/camera_skyboxes = list()
 
 # define MAX_ACTIVE_CAMERAS 4
 
@@ -56,7 +56,7 @@
 		camera_map_views[key] = cam
 
 		// Create the bounding-box canvas & effect overlay for the view
-		var/obj/screen/background/foreground = new
+		var/atom/movable/screen/background/foreground = new
 		foreground.screen_loc = "[key]:1,1 to [8],[6]"
 		foreground.icon = 'icons/primitives.dmi'
 		foreground.icon_state = "white"
@@ -79,8 +79,8 @@
 
 		// Create the local skybox for the camera
 		// Because the obj/skybox type is a sealed nasty piece of shit, we'll use
-		// obj/screen/background for now.
-		var/obj/screen/background/skybox = new
+		// atom/movable/screen/background for now.
+		var/atom/movable/screen/background/skybox = new
 		skybox.name = "skybox"
 		skybox.mouse_opacity = 0
 		skybox.blend_mode = BLEND_MULTIPLY
@@ -264,11 +264,11 @@
 	var/size_x = bbox[3] - bbox[1] + 1
 	var/size_y = bbox[4] - bbox[2] + 1
 
-	var/obj/screen/background/foreground = camera_foregrounds[index]
+	var/atom/movable/screen/background/foreground = camera_foregrounds[index]
 	foreground.icon_state = "blank"
 	foreground.screen_loc = "[key]:1,1 to [size_x],[size_y]"
 
-	var/obj/screen/background/skybox = camera_skyboxes[index]
+	var/atom/movable/screen/background/skybox = camera_skyboxes[index]
 	var/matrix/M = matrix()
 	// The skybox does not always cover the background, so upscale it a bit
 	M.Scale(between(1, 1 + max(size_x, size_y)/DEFAULT_VIEW_SIZE, 2))
@@ -283,7 +283,7 @@
 	var/atom/movable/map_view/MV = camera_map_views[key]
 	MV.vis_contents.Cut()
 
-	var/obj/screen/background/foreground = camera_foregrounds[index]
+	var/atom/movable/screen/background/foreground = camera_foregrounds[index]
 	foreground.icon_state = "white"
 	foreground.screen_loc = "[key]:1,1 to [8],[6]"
 	return TRUE

--- a/code/modules/multiz/open_darkness.dm
+++ b/code/modules/multiz/open_darkness.dm
@@ -1,4 +1,4 @@
-/obj/screen/openspace_overlay
+/atom/movable/screen/openspace_overlay
 	screen_loc = "CENTER,CENTER"
 	icon = 'icons/primitives.dmi'
 	icon_state = "black"
@@ -8,6 +8,6 @@
 	alpha = 255
 	mouse_opacity = FALSE
 
-/obj/screen/openspace_overlay/New()
+/atom/movable/screen/openspace_overlay/New()
 	. = ..()
 	src.transform = src.transform.Scale(32)

--- a/code/modules/organs/internal/species/nabber.dm
+++ b/code/modules/organs/internal/species/nabber.dm
@@ -35,7 +35,7 @@
 		if(eyes_shielded)
 			to_chat(owner, "<span class='notice'>Nearly opaque lenses slide down to shield your eyes.</span>")
 			innate_flash_protection = FLASH_PROTECTION_MAJOR
-			owner.overlay_fullscreen("eyeshield", /obj/screen/fullscreen/blind)
+			owner.overlay_fullscreen("eyeshield", /atom/movable/screen/fullscreen/blind)
 			owner.update_icons()
 		else
 			to_chat(owner, "<span class='notice'>Your protective lenses retract out of the way.</span>")

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -18,7 +18,7 @@
 /obj/item/weapon/clipboard/MouseDrop(obj/over_object as obj) //Quick clipboard fix. -Agouri
 	if(ishuman(usr))
 		var/mob/M = usr
-		if(!(istype(over_object, /obj/screen) ))
+		if(!(istype(over_object, /atom/movable/screen) ))
 			return ..()
 
 		if(!M.restrained() && !M.stat)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -114,7 +114,7 @@ var/global/photo_count = 0
 
 	if((istype(usr, /mob/living/carbon/human)))
 		var/mob/M = usr
-		if(!( istype(over_object, /obj/screen) ))
+		if(!( istype(over_object, /atom/movable/screen) ))
 			return ..()
 		playsound(loc, "rustle", 50, 1, -5)
 		if((!( M.restrained() ) && !( M.stat ) && M.back == src))

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -503,14 +503,14 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	if(!H.client)//no client, no screen to update
 		return 1
 
-	H.set_fullscreen(H.eye_blind && !H.equipment_prescription, "blind", /obj/screen/fullscreen/blind)
+	H.set_fullscreen(H.eye_blind && !H.equipment_prescription, "blind", /atom/movable/screen/fullscreen/blind)
 
 	if(config.welder_vision)
-		H.set_fullscreen(H.equipment_tint_total, "welder", /obj/screen/fullscreen/impaired, H.equipment_tint_total)
+		H.set_fullscreen(H.equipment_tint_total, "welder", /atom/movable/screen/fullscreen/impaired, H.equipment_tint_total)
 	var/how_nearsighted = get_how_nearsighted(H)
-	H.set_fullscreen(how_nearsighted, "nearsighted", /obj/screen/fullscreen/oxy, how_nearsighted)
-	H.set_fullscreen(H.eye_blurry, "blurry", /obj/screen/fullscreen/blurry)
-	H.set_fullscreen(H.druggy, "high", /obj/screen/fullscreen/high)
+	H.set_fullscreen(how_nearsighted, "nearsighted", /atom/movable/screen/fullscreen/oxy, how_nearsighted)
+	H.set_fullscreen(H.eye_blurry, "blurry", /atom/movable/screen/fullscreen/blurry)
+	H.set_fullscreen(H.druggy, "high", /atom/movable/screen/fullscreen/high)
 
 	for(var/overlay in H.equipment_overlays)
 		H.client.screen |= overlay

--- a/code/modules/urist/gamemodes/infestation/aliens/harvester.dm
+++ b/code/modules/urist/gamemodes/infestation/aliens/harvester.dm
@@ -104,25 +104,25 @@
 
 /datum/hud/proc/infestharvester_hud()
 
-	mymob.fire = new /obj/screen()
+	mymob.fire = new /atom/movable/screen()
 	mymob.fire.icon = 'icons/mob/screen1_construct.dmi'
 	mymob.fire.icon_state = "fire0"
 	mymob.fire.name = "fire"
 	mymob.fire.screen_loc = ui_construct_fire
 
-	mymob.healths = new /obj/screen()
+	mymob.healths = new /atom/movable/screen()
 	mymob.healths.icon = 'icons/mob/screen1_construct.dmi'
 	mymob.healths.icon_state = "harvester_health0"
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_construct_health
 
-	mymob.pullin = new /obj/screen()
+	mymob.pullin = new /atom/movable/screen()
 	mymob.pullin.icon = 'icons/mob/screen1_construct.dmi'
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_construct_pull
 
-	mymob.zone_sel = new /obj/screen/zone_sel()
+	mymob.zone_sel = new /atom/movable/screen/zone_sel()
 	mymob.zone_sel.icon = 'icons/mob/screen1_construct.dmi'
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")


### PR DESCRIPTION
## About The Pull Request

Fuck `obj/screen`s, all of my homies hate `obj/screens`. Embrace the way of `atom/movable/screen`. Doing so will exempt all screen objects from the labour and burden of being an object and everything it inherits. Plus it will not be in the object tree when used in a map maker like FastDMM2 or the default Dream Maker.

## Why It's Good For The Game

It is not supposed to be in the object tree, so pruning it from the the object tree will ease the map development. Thus making it better for everyone involved.

## Changelog
```changelog
add: Added potential bugs related to map UI elements
refactor: Renamned typepaths for UI elements to a special atom/movable instead for technical imporvements
```
