### PR TITLE
Add automatic localhost rank

### DIFF
--- a/check_regex.yaml
+++ b/check_regex.yaml
@@ -43,4 +43,4 @@ standards:
   - exactly: [0, 'superflous whitespace', '[ \t]+$']
   - exactly: [8, 'mixed indentation', '^( +\t+|\t+ +)']
 
-  - no_more: [1442, 'indentions inside defines', '^(\s*)#define (\w*)( {2,}| ?\t+)(?!(\/\/|\/\*))']
+  - no_more: [1443, 'indentions inside defines', '^(\s*)#define (\w*)( {2,}| ?\t+)(?!(\/\/|\/\*))']

--- a/code/__defines/admin.dm
+++ b/code/__defines/admin.dm
@@ -35,6 +35,7 @@
 #define R_MOD           0x2000
 #define R_MENTOR        0x4000
 #define R_HOST          0x8000 //higher than this will overflow
+#define R_EVERYTHING    (~0)
 #define R_INVESTIGATE   (R_ADMIN|R_MOD)
 
 #define R_MAXPERMISSION 0x8000 // This holds the maximum value for a permission. It is used in iteration, so keep it updated.

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -233,6 +233,8 @@ var/list/gamemode_cache = list()
 	var/asset_cdn_url = null
 	var/asset_transport = null
 
+	var/enable_localhost_rank = FALSE
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -277,6 +279,9 @@ var/list/gamemode_cache = list()
 
 		if(type == "config")
 			switch (name)
+				if ("enable_localhost_rank")
+					config.enable_localhost_rank = TRUE
+
 				if ("asset_simple_preload")
 					config.asset_simple_preload = 1
 

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -16,12 +16,11 @@ var/jobban_keylist[0]		//to store the keys & ranks
 //returns a reason if M is banned from rank, returns 0 otherwise
 /proc/jobban_isbanned(mob/M, rank)
 	if(M && rank)
-		/*
-		if(_jobban_isbanned(M, rank)) return "Reason Unspecified"	//for old jobban
-		*/
-
-		if (guest_jobbans(rank))
-			if(config.guest_jobban && IsGuestKey(M.key))
+		// WHY THE FUCK CAN M BE A client OBJECT WHEN IT IS SPECIFIED AS A mob VARIABLE???
+		// GOD DO I LOVE BYOND AND SS13 SHITCODE
+		var/client/C = (isclient(M) && M) || M.client
+		if (guest_jobbans(rank) && isnull(C.holder))
+			if(config.guest_jobban && IsGuestKey(C.key))
 				return "Guest Job-ban"
 			if(config.usewhitelist && !check_whitelist(M))
 				return "Whitelisted Job"

--- a/config/config.txt
+++ b/config/config.txt
@@ -13,6 +13,9 @@ ADMIN_LEGACY_SYSTEM
 ## Add a # infront of this if you want to use the SQL based banning system. The legacy systems use the files in the data folder. You need to set up your database to use the SQL based system.
 BAN_LEGACY_SYSTEM
 
+## Comment this out to stop locally connected clients from being given the almost full access !localhost! admin rank
+ENABLE_LOCALHOST_RANK
+
 ## Add a # here if you wish to use the setup where jobs have more access. This is intended for servers with low populations - where there are not enough players to fill all roles, so players need to do more than just one job. Also for servers where they don't want people to hide in their own departments.
 #JOBS_HAVE_MINIMAL_ACCESS
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -13,6 +13,9 @@ ADMIN_LEGACY_SYSTEM
 ## Add a # infront of this if you want to use the SQL based banning system. The legacy systems use the files in the data folder. You need to set up your database to use the SQL based system.
 BAN_LEGACY_SYSTEM
 
+## Comment this out to stop locally connected clients from being given the almost full access !localhost! admin rank
+ENABLE_LOCALHOST_RANK
+
 ## Add a # here if you wish to use the setup where jobs have more access. This is intended for servers with low populations - where there are not enough players to fill all roles, so players need to do more than just one job. Also for servers where they don't want people to hide in their own departments.
 JOBS_HAVE_MINIMAL_ACCESS
 


### PR DESCRIPTION
## About The Pull Request

The old state of things required you to have the Byond open and logged in 24/7 in order to be able to run and test the server things. Which was absolutely horrific from the perspective of quality life. So here, have automatic local privileges. It is currently hard-coded to grant `R_EVERYTHING`, which is just `~0` (aka, all 1s in every possible bit position in a Byond numeral).

Inspired by tgstation's automatic localhost rank.

## Why It's Good For The Game

Better quality of life for developers. -> Better development -> Better server -> Players have better time

## Changelog
```changelog
tweak: Localhosts now will be automatically given a total-control rank, it is enabled by default in the config, but false in code
tweak: Localhosts now can bypass guest-key checks as long the automatic rank is enabled
tweak: Admins now bypass guest and whitelist checks for jobs
```
