### PR TITLE
Port tgstation hover-over text

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -149,6 +149,7 @@
 #include "code\_onclick\hud\plane_master.dm"
 #include "code\_onclick\hud\robot.dm"
 #include "code\_onclick\hud\screen_objects.dm"
+#include "code\_onclick\hud\screen_tip.dm"
 #include "code\_onclick\hud\skybox.dm"
 #include "code\controllers\admin.dm"
 #include "code\controllers\autotransfer.dm"

--- a/check_regex.yaml
+++ b/check_regex.yaml
@@ -43,4 +43,4 @@ standards:
   - exactly: [0, 'superflous whitespace', '[ \t]+$']
   - exactly: [8, 'mixed indentation', '^( +\t+|\t+ +)']
 
-  - no_more: [1443, 'indentions inside defines', '^(\s*)#define (\w*)( {2,}| ?\t+)(?!(\/\/|\/\*))']
+  - no_more: [1444, 'indentions inside defines', '^(\s*)#define (\w*)( {2,}| ?\t+)(?!(\/\/|\/\*))']

--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -18,9 +18,10 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ATOM_FLAG_CLIMBABLE              (1<<1) // This object can be climbed on
 #define ATOM_FLAG_NO_BLOOD               (1<<2) // Used for items if they don't want to get a blood overlay.
 #define ATOM_FLAG_NO_REACT               (1<<3) // Reagents don't react inside this container.
-#define ATOM_FLAG_OPEN_CONTAINER         (1<<4) // Is an open container for chemistry purposes.
-#define ATOM_FLAG_INITIALIZED            (1<<5) // Has this atom been initialized
-#define ATOM_FLAG_OVERLAY_QUEUED         (1<<6) // Is this atom queued in SSoverlays
+#define ATOM_FLAG_NO_SCREEN_TIP          (1<<4) // Should this atom not display an screen tip
+#define ATOM_FLAG_OPEN_CONTAINER         (1<<5) // Is an open container for chemistry purposes.
+#define ATOM_FLAG_INITIALIZED            (1<<6) // Has this atom been initialized
+#define ATOM_FLAG_OVERLAY_QUEUED         (1<<7) // Is this atom queued in SSoverlays
 
 #define MOVABLE_FLAG_PROXMOVE            (1<<0) // Does this object require proximity checking in Enter()?
 

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -573,3 +573,6 @@
 	var/regex/R = regex("(\[^[char]\]*)$")
 	R.Find(text)
 	return R.group[1]
+
+/// Prepares a text to be used for maptext. Use this so it doesn't look hideous.
+#define MAPTEXT(text) {"<span class='maptext'>[##text]</span>"}

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -35,6 +35,8 @@
 	var/obj/screen/action_intent
 	var/obj/screen/move_intent
 
+	var/atom/movable/screen/screentip
+
 	var/obj/screen/plane_master/emissive/hud_emissive_catcher
 
 	var/list/adding

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -35,9 +35,7 @@
 	var/atom/movable/screen/action_intent
 	var/atom/movable/screen/move_intent
 
-	var/atom/movable/screen/screentip
-
-	var/atom/movable/screen/plane_master/emissive/hud_emissive_catcher
+	var/atom/movable/screen/screen_tip/screen_tip_text
 
 	var/list/adding
 	var/list/other
@@ -48,6 +46,7 @@
 
 	var/previous_z_depth
 	var/atom/movable/map_view/world_map_view
+	var/atom/movable/screen/plane_master/emissive/hud_emissive_catcher
 
 /datum/hud/proc/update_plane_masters()
 	if(!mymob || !mymob.client)
@@ -77,6 +76,7 @@
 
 /datum/hud/New(mob/owner)
 	mymob = owner
+	screen_tip_text = new/atom/movable/screen/screen_tip(null, src)
 	world_map_view = new/atom/movable/map_view()
 
 	hud_emissive_catcher = new/atom/movable/screen/plane_master/emissive()
@@ -98,6 +98,7 @@
 	adding = null
 	other = null
 	hotkeybuttons = null
+	QDEL_NULL(screen_tip_text)
 	QDEL_NULL(hud_emissive_catcher)
 	QDEL_NULL(world_map_view)
 	mymob = null
@@ -197,6 +198,7 @@
 
 	FinalizeInstantiation(ui_style, ui_color, ui_alpha)
 	mymob.client.screen += hud_emissive_catcher
+	mymob.client.screen += screen_tip_text
 
 /datum/hud/proc/FinalizeInstantiation(var/ui_style, var/ui_color, var/ui_alpha)
 	return

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -12,8 +12,12 @@
 	plane = HUD_PLANE
 	layer = HUD_BASE_LAYER
 	appearance_flags = NO_CLIENT_COLOR
-	var/obj/master = null	//A reference to the object in the slot. Grabs or items, generally.
-	var/globalscreen = FALSE //Global screens are not qdeled when the holding mob is destroyed.
+	/// A reference to the object in the slot. Grabs or items, generally.
+	var/obj/master = null
+	/// A reference to the owner HUD, if any.
+	var/datum/hud/hud = null
+	///Global screens are not qdeled when the holding mob is destroyed.
+	var/globalscreen = FALSE
 	appearance_flags = NO_CLIENT_COLOR
 
 /atom/movable/screen/update_plane()

--- a/code/_onclick/hud/screen_tip.dm
+++ b/code/_onclick/hud/screen_tip.dm
@@ -1,0 +1,18 @@
+/atom/movable/screen/screentip
+	icon = null
+	icon_state = null
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	screen_loc = "TOP,LEFT"
+	maptext_height = 480
+	maptext_width = 480
+	maptext = ""
+
+/atom/movable/screen/screentip/Initialize(mapload, _hud)
+	. = ..()
+	hud = _hud
+	update_view()
+
+/atom/movable/screen/screentip/proc/update_view(datum/source)
+	if(!hud) //Might not have been initialized by now
+		return
+	maptext_width = DEFAULT_VIEW_SIZE * world.icon_size

--- a/code/_onclick/hud/screen_tip.dm
+++ b/code/_onclick/hud/screen_tip.dm
@@ -1,4 +1,4 @@
-/atom/movable/screen/screentip
+/atom/movable/screen/screen_tip
 	icon = null
 	icon_state = null
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
@@ -7,12 +7,12 @@
 	maptext_width = 480
 	maptext = ""
 
-/atom/movable/screen/screentip/Initialize(mapload, _hud)
+/atom/movable/screen/screen_tip/Initialize(mapload, _hud)
 	. = ..()
 	hud = _hud
 	update_view()
 
-/atom/movable/screen/screentip/proc/update_view(datum/source)
+/atom/movable/screen/screen_tip/proc/update_view(datum/source)
 	if(!hud) //Might not have been initialized by now
 		return
 	maptext_width = DEFAULT_VIEW_SIZE * world.icon_size

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -572,7 +572,7 @@ its easier to just keep the beam vertical.
 		)
 			usr.hud_used.screen_tip_text.maptext = ""
 		else
-			usr.hud_used.screen_tip_text.maptext = MAPTEXT("<span class='center'>[name]</span>")
+			usr.hud_used.screen_tip_text.maptext = MAPTEXT("<span class='center screen-tip'>[name]</span>")
 
 
 /atom/proc/get_color()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -572,7 +572,12 @@ its easier to just keep the beam vertical.
 		)
 			usr.hud_used.screen_tip_text.maptext = ""
 		else
-			usr.hud_used.screen_tip_text.maptext = MAPTEXT("<span class='center screen-tip'>[name]</span>")
+			var/classes = jointext(list(
+				"center",
+				"screen-tip",
+				((usr.client?.get_preference_value(/datum/client_preference/style_screen_tip) == GLOB.PREF_YES) && "stylized") || ""
+			), " ")
+			usr.hud_used.screen_tip_text.maptext = MAPTEXT("<span class='[classes]'>[name]</span>")
 
 
 /atom/proc/get_color()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -561,6 +561,20 @@ its easier to just keep the beam vertical.
 	else
 		return ..()
 
+//Update the screentip to reflect what we're hoverin over
+/atom/MouseEntered(location, control, params)
+	. = ..()
+	// Screentips
+	if(usr?.hud_used)
+		if(\
+			!usr.client?.get_preference_value(/datum/client_preference/show_screen_tip) == GLOB.PREF_HIDE\
+			|| (atom_flags & ATOM_FLAG_NO_SCREEN_TIP)\
+		)
+			usr.hud_used.screen_tip_text.maptext = ""
+		else
+			usr.hud_used.screen_tip_text.maptext = MAPTEXT("<span class='center'>[name]</span>")
+
+
 /atom/proc/get_color()
 	return color
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -3,6 +3,8 @@
 	icon = 'icons/turf/flooring/plating.dmi'
 	icon_state = "plating"
 
+	atom_flags = ATOM_FLAG_NO_SCREEN_TIP
+
 	// Damage to flooring.
 	var/broken
 	var/burnt

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -7,6 +7,7 @@
 	dynamic_lighting = 0
 	luminosity = 1
 	temperature = T20C
+	atom_flags = ATOM_FLAG_NO_SCREEN_TIP
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 
 /turf/space/Initialize()

--- a/code/game/turfs/turf_null.dm
+++ b/code/game/turfs/turf_null.dm
@@ -5,6 +5,7 @@
 	density = 0
 	opacity = 1
 	luminosity = 0
+	atom_flags = ATOM_FLAG_NO_SCREEN_TIP
 	dynamic_lighting = FALSE
 
 /turf/null/New()

--- a/code/game/turfs/unsimulated/beach.dm
+++ b/code/game/turfs/unsimulated/beach.dm
@@ -1,6 +1,7 @@
 /turf/unsimulated/beach
 	name = "Beach"
 	icon = 'icons/misc/beach.dmi'
+	atom_flags = ATOM_FLAG_NO_SCREEN_TIP
 
 /turf/unsimulated/beach/sand
 	name = "Sand"

--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -2,6 +2,7 @@
 	name = "floor"
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "Floor3"
+	atom_flags = ATOM_FLAG_NO_SCREEN_TIP
 
 /turf/unsimulated/floor/bluespace //non-doomsday version of bluespace for transit and wizden
 	name = "\improper bluespace"

--- a/code/interface/stylesheet.dm
+++ b/code/interface/stylesheet.dm
@@ -17,141 +17,168 @@
 #define COLOUR_DARK_TEXT_NOTICE "#4495ff"
 #define COLOUR_DARK_TEXT_INFO "#23e47a"
 
-client/script = "<style>\
-body					{color:"	+ COLOUR_DARK_TEXT_BODY + ";	background-color:"	+ COLOUR_DARK_BG_DARKER + ";	font-family: Verdana, sans-serif;}\
-\
-h1, h2, h3, h4, h5, h6	{color:"	+ COLOUR_DARK_TEXT_NOTICE + ";	font-family: Georgia, Verdana, sans-serif;}\
-\
-em						{font-style: normal;font-weight: bold;}\
-\
-.motd					{color:"	+ COLOUR_DARK_TEXT_MOTD + ";	font-family: Verdana, sans-serif;}\
-.motd h1, .motd h2, .motd h3, .motd h4, .motd h5, .motd h6\
-						{color:"	+ COLOUR_DARK_TEXT_MOTD + ";	text-decoration: underline;}\
-.motd a, .motd a:link, .motd a:visited, .motd a:active, .motd a:hover\
-						{color:"	+ COLOUR_DARK_TEXT_MOTD + ";}\
-\
-.prefix					{font-weight: bold;}\
-.log_message			{color:"	+ "#386aff" + ";	font-weight: bold;}\
-\
-/* OOC */\
-.ooc					{font-weight: bold;}\
-.ooc img.text_tag		{width: 32px; height: 10px;}\
-\
-.ooc .everyone			{color:"	+ "#174be6" + ";}\
-.ooc .looc				{color:"	+ "#2bb1b1" + ";}\
-.ooc .elevated			{color:"	+ "#2e78d9" + ";}\
-.ooc .moderator			{color:"	+ "#275b96" + ";}\
-.ooc .developer			{color:"	+ "#2f8b35" + ";}\
-.ooc .admin				{color:"	+ "#c54014" + ";}\
-.ooc .aooc				{color:"	+ "#ca1b38" + ";}\
-\
-.staffwarn				{color:"	+ "#cc1f1f" + "; font-weight:bold; font-size: 150%;}\
-/* Admin: Private Messages */\
-.pm  .howto				{color:"	+ "#ff0000" + ";	font-weight: bold;		font-size: 200%;}\
-.pm  .in				{color:"	+ "#ff0000" + ";}\
-.pm  .out				{color:"	+ "#ff0000" + ";}\
-.pm  .other				{color:"	+ "#0000ff" + ";}\
-\
-/* Admin: Channels */\
-.mod_channel			{color:"	+ "#9e6d39" + ";	font-weight: bold;}\
-.mod_channel .admin		{color:"	+ "#c54014" + ";	font-weight: bold;}\
-.admin_channel			{color:"	+ "#9e43c9" + ";	font-weight: bold;}\
-\
-/* Radio: Misc */\
-.deadsay				{color:"	+ "#7334c5" + ";}\
-.radio					{color:"	+ "#60a32d" + ";}\
-.deptradio				{color:"	+ "#b334b3" + ";}	/* when all other department colors fail */\
-.newscaster				{color:"	+ "#a12424" + ";}\
-\
-/* Radio Channels */\
-.comradio				{color:"	+ "#375dbd" + ";}\
-.syndradio				{color:"	+ "#9c5d5e" + ";}\
-.centradio				{color:"	+ "#7373a3" + ";}\
-.airadio				{color:"	+ "#b334b3" + ";}\
-.entradio				{color:"	+ "#888888" + ";}\
-\
-.secradio				{color:"	+ "#ac1313" + ";}\
-.engradio				{color:"	+ "#b97713" + ";}\
-.medradio				{color:"	+ "#16aaaa" + ";}\
-.sciradio				{color:"	+ "#993399" + ";}\
-.supradio				{color:"	+ "#aa884d" + ";}\
-.srvradio				{color:"	+ "#86b11b" + ";}\
-.expradio				{color:"	+ "#b4bb27" + ";}\
-\
-/* Miscellaneous */\
-.name					{font-weight: bold;}\
-.say					{}\
-.alert					{color:"	+ COLOUR_DARK_TEXT_DANGER + ";}\
-h1.alert, h2.alert		{color:"	+ COLOUR_DARK_TEXT_BODY + ";}\
-\
-.emote					{font-style: italic;}\
-\
-/* Game Messages */\
-\
-.attack					{color:"	+ COLOUR_DARK_TEXT_CRITICAL + ";}\
-.moderate				{color:"	+ COLOUR_DARK_TEXT_DANGER + ";}\
-.disarm					{color:"	+ COLOUR_DARK_TEXT_WARNING + ";}\
-.passive				{color:"	+ COLOUR_DARK_TEXT_DANGER + ";}\
-\
-.critical				{color:"	+ COLOUR_DARK_TEXT_CRITICAL + "; font-weight: bold;}\
-.danger					{color:"	+ COLOUR_DARK_TEXT_DANGER + "; font-weight: bold;}\
-.warning				{color:"	+ COLOUR_DARK_TEXT_WARNING + "; font-style: italic;}\
-.boldannounce			{color:"	+ COLOUR_DARK_TEXT_DANGER + "; font-weight: bold;}\
-.sinister				{color:"	+ "#800080" + "; font-weight: bold;	font-style: italic;}\
-.rose					{color:"	+ "#ff5050" + ";}\
-.info					{color:"	+ COLOUR_DARK_TEXT_INFO + ";}\
-.notice					{color:"	+ COLOUR_DARK_TEXT_NOTICE + ";}\
-.alium					{color:"	+ "#00ff00" + ";}\
-.cult					{color:"	+ "#800080" + "; font-weight: bold; font-style: italic;}\
-.fountain				{color:"	+ "#800080" + "; font-style: italic; font-size: 175%;}\
-\
-.reflex_shoot			{color:"	+ "#000099" + "; font-style: italic;}\
-\
-/* Languages */\
-\
-.alien					{color:"	+ "#543354" + ";}\
-.skrell					{color:"	+ "#00ced1" + ";}\
-.soghun					{color:"	+ "#228b22" + ";}\
-.nabber_lang			{color:"	+ "#525252" + ";}\
-.solcom					{color:"	+ "#22228b" + ";}\
-.changeling				{color:"	+ "#800080" + ";}\
-.vox					{color:"	+ "#aa00aa" + ";}\
-.rough					{font-family: \"Trebuchet MS\", cursive, sans-serif;}\
-.say_quote				{font-family: Georgia, Verdana, sans-serif;}\
-.terran					{color:"	+ "#9c250b" + ";}\
-.moon					{color:"	+ "#422863" + ";}\
-.spacer					{color:"	+ "#ff6600" + ";}\
-.adherent				{color:"	+ "#526c7a" + ";}\
-\
-.interface				{color:"	+ "#330033" + ";}\
-\
-.good                   {color:"	+ "#4f7529" + "; font-weight: bold;}\
-.bad                    {color:"	+ "#ee0000" + "; font-weight: bold;}\
-\
-BIG IMG.icon 			{width: 32px; height: 32px;}\
-\
-</style>"
-
 /proc/byond_map_theme()
-	return {"
-	.center {
-		text-align: center;
-	}
-	.maptext {
-		font-family: 'Small Fonts';
-		font-size: 7px;
-		color: white;
-		line-height: 1.1;
-		-dm-text-outline: 1px black;
-	}
-	"}
+	var/static/map_theme_cache = null
+	if(!map_theme_cache)
+		map_theme_cache = {"
+.center {
+	text-align: center;
+}
+.maptext {
+	font-family: 'Small Fonts';
+	font-size: 7px;
+	color: white;
+	line-height: 1.1;
+	-dm-text-outline: 1px black;
+}
+.screen-tip {
+	font-size: 16px;
+}
+"}
+	return map_theme_cache
+
+/proc/byond_output_theme()
+	var/static/output_theme_cache = null
+	if (!output_theme_cache)
+		output_theme_cache = {"
+body {
+	color: [COLOUR_DARK_TEXT_BODY];
+	background-color:[COLOUR_DARK_BG_DARKER];
+	font-family: Verdana, sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	color:[COLOUR_DARK_TEXT_NOTICE];
+	font-family: Georgia, Verdana, sans-serif;
+}
+
+em {
+	font-style: normal;
+	font-weight: bold;
+}
+
+.motd {
+	color:[COLOUR_DARK_TEXT_MOTD];
+	font-family: Verdana, sans-serif;
+}
+
+.motd h1, .motd h2, .motd h3, .motd h4, .motd h5, .motd h6 {
+	color:[COLOUR_DARK_TEXT_MOTD];
+	text-decoration: underline;
+}
+
+.motd a, .motd a:link, .motd a:visited, .motd a:active, .motd a:hover {
+	color:[COLOUR_DARK_TEXT_MOTD];
+}
+
+.prefix             {font-weight: bold;}
+.log_message        {color:["#386aff"];	font-weight: bold;}
+
+/* OOC */
+.ooc                {font-weight: bold;}
+.ooc img.text_tag   {width: 32px; height: 10px;}
+
+.ooc .everyone      {color:["#174be6"];}
+.ooc .looc          {color:["#2bb1b1"];}
+.ooc .elevated      {color:["#2e78d9"];}
+.ooc .moderator	    {color:["#275b96"];}
+.ooc .developer     {color:["#2f8b35"];}
+.ooc .admin         {color:["#c54014"];}
+.ooc .aooc          {color:["#ca1b38"];}
+
+/* Admin: Private Messages */
+.staffwarn          {color:["#cc1f1f"]; font-weight:bold; font-size: 150%;}
+.pm  .howto         {color:["#ff0000"];	font-weight: bold;		font-size: 200%;}
+.pm  .in            {color:["#ff0000"];}
+.pm  .out           {color:["#ff0000"];}
+.pm  .other         {color:["#0000ff"];}
+
+/* Admin: Channels */
+.mod_channel        {color:["#9e6d39"];	font-weight: bold;}
+.mod_channel .admin {color:["#c54014"];	font-weight: bold;}
+.admin_channel      {color:["#9e43c9"];	font-weight: bold;}
+
+/* Radio: Misc */
+.deadsay            {color:["#7334c5"];}
+.radio              {color:["#60a32d"];}
+.deptradio          {color:["#b334b3"];}	/* when all other department colors fail */
+.newscaster         {color:["#a12424"];}
+
+/* Radio Channels */
+.comradio           {color:["#375dbd"];}
+.syndradio          {color:["#9c5d5e"];}
+.centradio          {color:["#7373a3"];}
+.airadio            {color:["#b334b3"];}
+.entradio           {color:["#888888"];}
+
+.secradio           {color:["#ac1313"];}
+.engradio           {color:["#b97713"];}
+.medradio           {color:["#16aaaa"];}
+.sciradio           {color:["#993399"];}
+.supradio           {color:["#aa884d"];}
+.srvradio           {color:["#86b11b"];}
+.expradio           {color:["#b4bb27"];}
+
+/* Miscellaneous */
+.name               {font-weight: bold;}
+.say                {}
+.alert              {color:[COLOUR_DARK_TEXT_DANGER];}
+h1.alert, h2.alert  {color:[COLOUR_DARK_TEXT_BODY];}
+
+.emote              {font-style: italic;}
+
+/* Game Messages */
+.attack	            {color:[COLOUR_DARK_TEXT_CRITICAL];}
+.moderate           {color:[COLOUR_DARK_TEXT_DANGER];}
+.disarm             {color:[COLOUR_DARK_TEXT_WARNING];}
+.passive            {color:[COLOUR_DARK_TEXT_DANGER];}
+
+.critical           {color:[COLOUR_DARK_TEXT_CRITICAL]; font-weight: bold;}
+.danger             {color:[COLOUR_DARK_TEXT_DANGER]; font-weight: bold;}
+.warning            {color:[COLOUR_DARK_TEXT_WARNING]; font-style: italic;}
+.boldannounce       {color:[COLOUR_DARK_TEXT_DANGER]; font-weight: bold;}
+.sinister           {color:["#800080"]; font-weight: bold;	font-style: italic;}
+.rose               {color:["#ff5050"];}
+.info               {color:[COLOUR_DARK_TEXT_INFO];}
+.notice             {color:[COLOUR_DARK_TEXT_NOTICE];}
+.alium              {color:["#00ff00"];}
+.cult               {color:["#800080"]; font-weight: bold; font-style: italic;}
+.fountain           {color:["#800080"]; font-style: italic; font-size: 175%;}
+
+.reflex_shoot       {color:["#000099"]; font-style: italic;}
+
+/* Languages */
+
+.alien              {color:["#543354"];}
+.skrell             {color:["#00ced1"];}
+.soghun             {color:["#228b22"];}
+.nabber_lang        {color:["#525252"];}
+.solcom	            {color:["#22228b"];}
+.changeling         {color:["#800080"];}
+.vox                {color:["#aa00aa"];}
+.rough              {font-family: \"Trebuchet MS\", cursive, sans-serif;}
+.say_quote          {font-family: Georgia, Verdana, sans-serif;}
+.terran             {color:["#9c250b"];}
+.moon               {color:["#422863"];}
+.spacer             {color:["#ff6600"];}
+.adherent           {color:["#526c7a"];}
+
+.interface          {color:["#330033"];}
+
+.good               {color:["#4f7529"]; font-weight: bold;}
+.bad                {color:["#ee0000"]; font-weight: bold;}
+
+BIG IMG.icon        {width: 32px; height: 32px;}
+"}
+	return output_theme_cache
 
 /*
  * Should be used in all unique mob/Login() procs
  */
 /proc/apply_global_theme(client/user)
 	apply_skin_theme(user, list(
-		"mapwindow.map.style=[byond_map_theme()]"
+		"mapwindow.map.style=\"[byond_map_theme()]\"",
+		"outputwindow.output.style=\"[byond_output_theme()]\""
 	))
 	apply_dark_theme(user)
 

--- a/code/interface/stylesheet.dm
+++ b/code/interface/stylesheet.dm
@@ -25,14 +25,21 @@
 	text-align: center;
 }
 .maptext {
-	font-family: 'Small Fonts';
-	font-size: 7px;
+	font-family: san-serif;
+	font-size: 8px;
 	color: white;
-	line-height: 1.1;
+	line-height: 0.6;
 	-dm-text-outline: 1px black;
 }
 .screen-tip {
-	font-size: 16px;
+	font-size: 12px;
+	font-weight: 900;
+}
+.stylized {
+	font-family: 'Consolas', san-serif;
+}
+.clown {
+	font-family: 'Comic Sans MS', san-serif;
 }
 "}
 	return map_theme_cache

--- a/code/interface/stylesheet.dm
+++ b/code/interface/stylesheet.dm
@@ -132,10 +132,27 @@ BIG IMG.icon 			{width: 32px; height: 32px;}\
 \
 </style>"
 
+/proc/byond_map_theme()
+	return {"
+	.center {
+		text-align: center;
+	}
+	.maptext {
+		font-family: 'Small Fonts';
+		font-size: 7px;
+		color: white;
+		line-height: 1.1;
+		-dm-text-outline: 1px black;
+	}
+	"}
+
 /*
  * Should be used in all unique mob/Login() procs
  */
 /proc/apply_global_theme(client/user)
+	apply_skin_theme(user, list(
+		"mapwindow.map.style=[byond_map_theme()]"
+	))
 	apply_dark_theme(user)
 
 /proc/apply_skin_theme(client/user, list/theme)

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -135,6 +135,11 @@ var/list/_client_preferences_by_type
 	key = "CHAT_SHOWICONS"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
+/datum/client_preference/show_screen_tip
+	description ="Hover-over screen indicator"
+	key = "SHOW_SCREEN_TIP"
+	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
+
 /datum/client_preference/show_typing_indicator
 	description ="Typing indicator"
 	key = "SHOW_TYPING"

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -136,9 +136,14 @@ var/list/_client_preferences_by_type
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
 /datum/client_preference/show_screen_tip
-	description ="Hover-over screen indicator"
+	description ="Hover-over indicator"
 	key = "SHOW_SCREEN_TIP"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
+
+/datum/client_preference/style_screen_tip
+	description ="Stylize Hover-over indictor"
+	key = "STYLE_SCREEN_TIP"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
 
 /datum/client_preference/show_typing_indicator
 	description ="Typing indicator"


### PR DESCRIPTION
## About The Pull Request

Ports the "screen-tip" from tgstation that looks like this.
![image](https://user-images.githubusercontent.com/13331724/133003404-87740564-1f62-40f3-b774-e7746cdb1827.png)

While porting it, it was made necessary to rewrite how the stylesheet is loaded into Byond and clients. Now it should be more flexible and powerful at little performance cost. But the stability and reliability is yet to be seen.

## Why It's Good For The Game

So we can get rid of that fucking status bar in the future.

## Changelog
```changelog
add: A popup text at top of screen will appear when howevering over an atom
add: Preference (in Global category) allowing players to show or hide the popup text. It is turned on by default.
add: Preference (in Global category) controlling whether the hover-over should display in either the stylic or the San Serif font.
tweak: Byond interface CSS is now compiled and loaded at runtime instead of compile-time
```
