### PR TITLE
Fix missing synth/posi culture for Pluto

### DIFF
--- a/Haven/Maps/TycloPluto/datums/lore/_module_lore_ah13.dm
+++ b/Haven/Maps/TycloPluto/datums/lore/_module_lore_ah13.dm
@@ -15,7 +15,7 @@
 	Either way, this is how the sytem works:
 
 	1. Define name macros with human-readable string values
-	2. Use the macros inside /decl/culture_info declarations and definitions
+	2. Use the macros inside /decl/cultural_info declarations and definitions
 	3. Put them inside species datums' available_cultural_info list of associated
 		lists with corresponding tags;
 		- Cultures                   -> TAG_CULTURE
@@ -39,6 +39,7 @@
 // Define culture
 #include "cultures/cultures_common.dm"
 #include "cultures/cultures_human.dm"
+#include "cultures/cultures_machine.dm"
 #include "cultures/cultures_skrell.dm"
 #include "cultures/cultures_teshari.dm"
 #include "cultures/cultures_unathi.dm"

--- a/Haven/Maps/TycloPluto/datums/lore/cultures/cultures_machine.dm
+++ b/Haven/Maps/TycloPluto/datums/lore/cultures/cultures_machine.dm
@@ -1,0 +1,15 @@
+/decl/cultural_info/culture/synth
+	name = CULTURE_SYNTHMORPHS
+	description = {"
+		As a synthmorph, you are either a free mind born out of an artifical consciousness
+		training factory, a copy of an uploaded mind pattern, or simply a consciousness
+		transferred from an old body. You have the necessary identity for a synthmorph,
+		and have the freedom to identify yourself to a culture of choice or other. Or just
+		simply take pride in being a synthmorph.
+	"}
+	language = LANGUAGE_EAL
+	name_language = LANGUAGE_EAL
+	additional_langs = list(LANGUAGE_GALCOM)
+
+/decl/cultural_info/culture/synth/sanitize_name(var/new_name)
+	return sanitizeName(new_name, allow_numbers = 1)

--- a/Haven/Maps/TycloPluto/datums/lore/species_overrides/machine.dm
+++ b/Haven/Maps/TycloPluto/datums/lore/species_overrides/machine.dm
@@ -3,7 +3,7 @@
 
 	available_cultural_info = list(
 		TAG_CULTURE = list(
-			CULTURE_POSITRONICS,
+			CULTURE_SYNTHMORPHS,
 			CULTURE_OTHER_AH13
 		),
 		TAG_HOMEWORLD = list(
@@ -36,7 +36,7 @@
 	)
 
 	default_cultural_info = list(
-		TAG_CULTURE = CULTURE_POSITRONICS,
+		TAG_CULTURE = CULTURE_SYNTHMORPHS,
 		TAG_HOMEWORLD = HOME_SYSTEM_OTHER,
 		TAG_FACTION = FACTION_OTHER
 	)

--- a/Haven/Maps/TycloPluto/datums/lore/strings_names.dm
+++ b/Haven/Maps/TycloPluto/datums/lore/strings_names.dm
@@ -12,6 +12,8 @@
 #define CULTURE_SOLARIAN      "Solarian"
 #define CULTURE_OLD_EARTHER   "Old Earther"
 
+#define CULTURE_SYNTHMORPHS   "Synthmorphs"
+
 #define CULTURE_MOGHES        "Old Moghei"
 #define CULTURE_POST_MOGHES   "Post-Moghei"
 #define CULTURE_NAGNECAN      "Nagnecan"

--- a/check_regex.yaml
+++ b/check_regex.yaml
@@ -43,4 +43,4 @@ standards:
   - exactly: [0, 'superflous whitespace', '[ \t]+$']
   - exactly: [8, 'mixed indentation', '^( +\t+|\t+ +)']
 
-  - no_more: [1444, 'indentions inside defines', '^(\s*)#define (\w*)( {2,}| ?\t+)(?!(\/\/|\/\*))']
+  - no_more: [1445, 'indentions inside defines', '^(\s*)#define (\w*)( {2,}| ?\t+)(?!(\/\/|\/\*))']


### PR DESCRIPTION
## About The Pull Request

There were an issue with the machine species on the Pluto map, where name check failed due to a missing culture declaration meant for the machine. So this adds the missing culture.

## Why It's Good For The Game

Makes the game playable

## Changelog
```changelog
add: Added the Synthmorph culture, the default culture for the Machine/IPC species on the Pluto map
```