### PR TITLE
Add portable generator UI

### DIFF
--- a/tgui/packages/tgui/interfaces/power/PortableGenerator.js
+++ b/tgui/packages/tgui/interfaces/power/PortableGenerator.js
@@ -57,7 +57,7 @@ export const PortableGenerator = (props, context) => {
                 ranges={{
                   good: [-Infinity, 0.6],
                   average: [0.6, 0.8],
-                  bad: [0.8, Infinity]
+                  bad: [0.8, Infinity],
                 }}
               />
             </LabeledList.Item>
@@ -79,7 +79,7 @@ export const PortableGenerator = (props, context) => {
                     maxValue={data.output_max}
                     ranges={{
                       default: [-Infinity, data.output_safe],
-                      average: [data.output_safe, Infinity]
+                      average: [data.output_safe, Infinity],
                     }}
                   >
                     {data.output_set} / {data.output_max}


### PR DESCRIPTION
## About The Pull Request

In issue #84 it was mentioned that the pacman generators failed to load UIs because they did not exist. One existing one was found in a different name. It has been edited along with the DM code changed to use the new tgUI.

## Why It's Good For The Game

Makes the game playable

## Changelog
```changelog
add: Added tgUI for portable generators
```
