### PR TITLE
Fix qdel runtimes caused by `map_view`

### DIFF
--- a/code/_helpers/qdel.dm
+++ b/code/_helpers/qdel.dm
@@ -7,7 +7,8 @@
 #define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/I in L) qdel(L[I]); L.Cut(); }
 
 #define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) } ; x = null }
-#define QDEL_NULL_ASSOC_LIST(x) if(x) { for(var/y in x) { qdel(x[y]); x[y] = null; qdel(y) } ; x = null }
+#define QDEL_NULL_ASSOC_LIST(x) if(x) { for(var/y in x) { qdel(x[y]); x[y] = null; qdel(y);} ; x = null }
+#define QDEL_NULL_ASSOC_VAL_LIST(x) if(x) { for(var/y in x) { qdel(x[y]); x[y] = null;} ; x = null }
 
 //the underscores are to encourage people not to use this directly.
 /proc/______qdel_list_wrapper(list/L)

--- a/code/_onclick/hud/map_view.dm
+++ b/code/_onclick/hud/map_view.dm
@@ -11,8 +11,8 @@
 
 /atom/movable/map_view/Destroy()
 	. = ..()
-	QDEL_NULL_ASSOC_LIST(plane_master_cache)
-	QDEL_NULL_ASSOC_LIST(openspace_overlay_cache)
+	QDEL_NULL_ASSOC_VAL_LIST(plane_master_cache)
+	QDEL_NULL_ASSOC_VAL_LIST(openspace_overlay_cache)
 	// Just null those lists, they are subsets of the caches above
 	// Or do you want to get a spam of "could not GC X"?
 	active_planes = null


### PR DESCRIPTION
## About The Pull Request

Since #23, there has been very easy to miss runtime due to how debugging sessions had been run. Often ungracefully killed and destroyed when done. The runtimes were the string keys used for associative lists in `atom/movable/map_view` being qdelled, which was invalid. So this fixes this particular issue.

## Why It's Good For The Game

Less runtimes. Less clutter. Less garbage in the active memory. Better performance. Better game.

## Changelog
```changelog
fix: Fixed runtimes caused by improper garbage collection of unused map-views.
```