### PR TITLE
Enforce `SHOULD_NOT_SLEEP` in `Destroy`

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -16,6 +16,8 @@
 // This should be overridden to remove all references pointing to the object being destroyed.
 // Return the appropriate QDEL_HINT; in most cases this is QDEL_HINT_QUEUE.
 /datum/proc/Destroy(force=FALSE)
+	SHOULD_NOT_SLEEP(TRUE)
+
 	tag = null
 	SStgui && SStgui.close_uis(src)
 	var/list/timers = active_timers

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -87,12 +87,10 @@
 					AM.Crossed(src)
 			if(is_new_area && is_destination_turf)
 				destination.loc.Entered(src, origin)
-
-	// Only update plane if we're located on map
-	if (isturf(src.loc))
-		// if we wasn't on map OR our Z coord was changed
-		if (!isturf(origin) || (get_z(loc) != get_z(origin)))
-			update_plane()
+			// Only update plane if we're located on map
+			// if we wasn't on map OR our Z coord was changed
+			if (!is_origin_turf || (get_z(loc) != get_z(origin)))
+				update_plane()
 
 	return 1
 

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -9,16 +9,6 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley
 	cargo_capacity = 10
 
-/obj/mecha/working/ripley/Destroy()
-	for(var/atom/movable/A in src.cargo)
-		A.loc = loc
-		var/turf/T = loc
-		if(istype(T))
-			T.Entered(A)
-		step_rand(A)
-	cargo.Cut()
-	..()
-
 /obj/mecha/working/ripley/firefighter
 	desc = "Standart APLU chassis was refitted with additional thermal protection and cistern."
 	name = "APLU \"Firefighter\""

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -11,19 +11,14 @@
 
 /obj/mecha/working/Destroy()
 	for(var/mob/M in src)
-		if(M==src.occupant)
+		if(M==src.occupant) // will be handled in go_out in parent
 			continue
-		M.loc = get_turf(src)
-		M.loc.Entered(M)
+		M.dropInto(src.loc)
 		step_rand(M)
 	for(var/atom/movable/A in src.cargo)
-		A.loc = get_turf(src)
-		var/turf/T = get_turf(A)
-		if(T)
-			T.Entered(A)
+		A.dropInto(src.loc)
 		step_rand(A)
-	..()
-	return
+	return ..()
 
 /obj/mecha/working/Topic(href, href_list)
 	..()

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -43,6 +43,7 @@
 	return 1
 
 /obj/proc/unbuckle_mob()
+	set waitfor = 0
 	if(buckled_mob && buckled_mob.buckled == src)
 		. = buckled_mob
 		buckled_mob.buckled = null

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -37,8 +37,6 @@
 /obj/effect/effect/smoke/chem/Destroy()
 	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
 	set_opacity(0)
-	// TODO - fadeOut() sleeps.  Sleeping in /Destroy is Bad, this needs to be fixed.
-	fadeOut()
 	return ..()
 
 /obj/effect/effect/smoke/chem/Move()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -143,24 +143,24 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/Crossed(var/mob/living/M)
 	if(seed && seed.get_trait(TRAIT_JUICY) == 2)
 		if(istype(M))
-
 			if(M.buckled)
 				return
-
 			if(istype(M,/mob/living/carbon/human))
 				var/mob/living/carbon/human/H = M
 				if(H.shoes && H.shoes.item_flags & ITEM_FLAG_NOSLIP)
 					return
+			stepped_on(M)
 
-			M.stop_pulling()
-			to_chat(M, "<span class='notice'>You slipped on the [name]!</span>")
-			playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-			M.Stun(8)
-			M.Weaken(5)
-			seed.thrown_at(src,M)
-			sleep(-1)
-			if(src) qdel(src)
-			return
+/obj/item/weapon/reagent_containers/food/snacks/grown/proc/stepped_on(mob/living/M)
+	set waitfor = 0
+	M.stop_pulling()
+	to_chat(M, "<span class='notice'>You slipped on the [name]!</span>")
+	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+	M.Stun(8)
+	M.Weaken(5)
+	seed.thrown_at(src,M)
+	sleep(-1)
+	if(src) qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom)
 	if(seed) seed.thrown_at(src,hit_atom)

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -140,6 +140,7 @@
 
 // Relays kill program request to currently active program. Use this to quit current program.
 /obj/item/modular_computer/proc/kill_program(var/forced = 0)
+	set waitfor = 0
 	if(active_program)
 		active_program.kill_program(forced)
 		active_program = null

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -64,15 +64,13 @@
 	check_armour = "bullet"
 
 	Bump(atom/A as mob|obj|turf|area, forced)
+		if(!istype(A))
+			return 0
 		if(A == firer)
 			loc = A.loc
-			return
-
-		sleep(-1) //Might not be important enough for a sleep(-1) but the sleep/spawn itself is necessary thanks to explosions and metoerhits
-
+			return 0
 		if(src)//Do not add to this if() statement, otherwise the meteor won't delete them
 			if(A)
-
 				A.ex_act(2)
 				playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
 

--- a/code/modules/urist/machinery/misc.dm
+++ b/code/modules/urist/machinery/misc.dm
@@ -1,15 +1,3 @@
-/obj/machinery/mass_driver/sm_launcher
-	name = "gravity driver"
-	desc = "A special mass driver keyed to launch the supermatter when ejected."
-
-
-/obj/machinery/mass_driver/sm_launcher/Crossed(O as obj)
-	..()
-	if(istype(O, /obj/machinery/power/supermatter))
-		sleep(25) //so the sm can land
-		drive()
-
-
 /obj/structure/curtain/var/id = null
 
 /obj/machinery/button/remote/curtains


### PR DESCRIPTION
## About The Pull Request

Adds `SHOULD_NOT_SLEEP(TRUE)` to `Destroy` in `/datum` to ensure that there are no calls to procs that don't have any variety of blocking procs or procs that require it, yet don't have the `set waitfor = 0` attribute.

## Why It's Good For The Game

Hopefully it should help the stability and performance of the garbage collector and the MC. Or cause it to go up flames in a quite fun way.

## Changelog
```changelog
tweak: Blocking procs and calls have been forbidden from garbage collection procs
```